### PR TITLE
refactor: stable LP token pricing for bonding

### DIFF
--- a/contracts/interfaces/IErrorsTokenomics.sol
+++ b/contracts/interfaces/IErrorsTokenomics.sol
@@ -60,13 +60,6 @@ interface IErrorsTokenomics {
     /// @param actual Actual supply left.
     error ProductSupplyLow(address tokenAddress, uint256 productId, uint256 requested, uint256 actual);
 
-    /// @dev The product supply is low for the requested payout.
-    /// @param tokenAddress Address of a token.
-    /// @param productId Product Id.
-    /// @param slippage Tolerance.
-    error ProductSlippageOverflow(address tokenAddress, uint256 productId, uint256 slippage);
-
-
     /// @dev Minting is rejected due to the requested amount bigger than the current inflation policy cap.
     /// @param amount Amount of tokens to mint.
     error MintRejectedByInflationPolicy(uint256 amount);

--- a/contracts/interfaces/ITokenomics.sol
+++ b/contracts/interfaces/ITokenomics.sol
@@ -11,10 +11,11 @@ interface ITokenomics {
     function checkpoint() external;
 
     /// @dev Calculates the amount of OLAS tokens based on LP.
-    /// @param token Token address.
-    /// @param tokenAmount Token amount.
+    /// @param tokenAmount LP token amount.
+    /// @param priceLP LP token price.
     /// @return amountOLAS Resulting amount of OLAS tokens.
-    function calculatePayoutFromLP(address token, uint256 tokenAmount) external returns (uint256 amountOLAS);
+    function calculatePayoutFromLP(uint256 tokenAmount, uint256 priceLP) external
+        returns (uint256 amountOLAS);
 
     /// @dev Tracks the deposited ETH amounts from services during the current epoch.
     /// @param serviceIds Set of service Ids.
@@ -58,13 +59,6 @@ interface ITokenomics {
     /// @return accountTopUps Cumulative staker, component and agent top-ups.
     function getRewardsData() external view
         returns (uint256 treasuryRewards, uint256 accountRewards, uint256 accountTopUps);
-
-    /// @dev check reserve ratio in slippage range
-    /// @param token Token address.
-    /// @param priceLP Reserve ration by create.
-    /// @param slippage tolerance in reserve ratio %.
-    /// @return True if successful.
-    function slippageIsOK(address token, uint256 priceLP, uint256 slippage) external view returns (bool);
 
     /// @dev Get reserveX/reserveY at the time of product creation.
     /// @param token Token address.

--- a/contracts/test/AttackDeposit.sol
+++ b/contracts/test/AttackDeposit.sol
@@ -3,12 +3,9 @@ pragma solidity ^0.8.14;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@uniswap/v2-core/contracts/interfaces/IUniswapV2Pair.sol";
-import "hardhat/console.sol";
 
 interface IDepository {
     function deposit(address token, uint256 productId, uint256 tokenAmount, address user) external
-        returns (uint256 payout, uint256 expiry, uint256 numBonds);
-    function depositOriginal(address token, uint256 productId, uint256 tokenAmount, address user) external
         returns (uint256 payout, uint256 expiry, uint256 numBonds);
 }
 
@@ -28,46 +25,16 @@ contract AttackDeposit {
     
     constructor() {}
 
-    // @dev emulate deposit process from EOA
-    // @param depository Address of depository.
-    // @param token Address of pair
-    // @param olas Address of OLAS token
-    // @param bid number of bid
-    // @param amountTo amount LP for deposit. 
-    function normalDeposit(address depository, address token, address olas, uint256 bid, uint256 amountTo) external {        
-        IUniswapV2Pair pair = IUniswapV2Pair(address(token));
-        address token0 = pair.token0();
-        address token1 = pair.token1();
-        uint256 balance0 = IERC20(token0).balanceOf(address(pair));
-        uint256 balance1 = IERC20(token1).balanceOf(address(pair));
-        uint256 totalSupply = pair.totalSupply();
-        uint256 balanceOLA = (token0 == olas) ? balance0 : balance1;
-        console.log("AttackDeposit ## OLAS reserved before deposi", balanceOLA);
-        
-        // Trying to deposit the amount that would result in an overflow payout for the LP supply
-        // await pairODAI.connect(deployer).approve(depository.address, LARGE_APPROVAL);
-        // depository.connect(deployer).deposit(pairODAI.address, bid, amountTo, deployer.address);
-        IERC20(token).approve(depository, LARGE_APPROVAL);
-        (uint256 payout, uint256 expiry, uint256 numBonds) = IDepository(depository).deposit(token, bid, amountTo, address(this));
-        console.log("AttackDeposit ## payout", payout);
-        console.log("AttackDeposit ## expiry", expiry);
-        console.log("AttackDeposit ## numBonds", numBonds);
-        
-        balance0 = IERC20(token0).balanceOf(address(pair));
-        balance1 = IERC20(token1).balanceOf(address(pair));
-        totalSupply = pair.totalSupply();
-        balanceOLA = (token0 == olas) ? balance0 : balance1;
-        console.log("AttackDeposit ## OLAS reserved after deposit", balanceOLA);
-    }
-
-    // @dev emulate attack against deposit without slippage check
+    // @dev emulate attack against deposit.
     // @param depository Address of depository.
     // @param token Address of pair
     // @param olas Address of OLAS token
     // @param bid number of bid
     // @param amountTo amount LP for deposit.
     // @param swapRouter uniswapV2 router address 
-    function attackDepositMustSuccess(address depository, address token, address olas, uint256 bid, uint256 amountTo, address swapRouter) external {
+    function flashAttackDepositImmune(address depository, address token, address olas, uint256 bid, uint256 amountTo, address swapRouter) external
+        returns (uint256 payout)
+    {
         // Trying to deposit the amount that would result in an overflow payout for the LP supply
         // await pairODAI.connect(deployer).approve(depository.address, LARGE_APPROVAL);
         // depository.connect(deployer).deposit(pairODAI.address, bid, amountTo, deployer.address);
@@ -83,28 +50,27 @@ contract AttackDeposit {
         // uint256 totalSupply = pair.totalSupply();
         uint256 balanceOLA = (token0 == olas) ? balance0 : balance1;
         uint256 balanceDAI = (token0 == olas) ? balance1 : balance0;
-        console.log("AttackDeposit ## OLAS reserved before deposi", balanceOLA);
-        console.log("AttackDeposit ## DAI reserved before deposi", balanceDAI);
+        // console.log("AttackDeposit ## OLAS reserved before deposit", balanceOLA);
+        // console.log("AttackDeposit ## DAI reserved before deposit", balanceDAI);
         // uint256 amountToSwap = IERC20(olas).balanceOf(address(this));
 
         path[0] = (token0 == olas) ? token0 : token1;
         path[1] = (token0 == olas) ? token1 : token0;
 
-        console.log("balance OLAS in this contract before swap {pseudo flash loan OLAS}:",IERC20(olas).balanceOf(address(this)));
+        // console.log("balance OLAS in this contract before swap {pseudo flash loan OLAS}:",IERC20(olas).balanceOf(address(this)));
         IERC20(olas).approve(swapRouter, LARGE_APPROVAL);
         amounts = IRouter(swapRouter).swapExactTokensForTokens(IERC20(olas).balanceOf(address(this)), 0, path, address(this), block.timestamp + 3000);
-        console.log("balance OLAS in this contract after swap:",IERC20(olas).balanceOf(address(this)));
+        // console.log("balance OLAS in this contract after swap:",IERC20(olas).balanceOf(address(this)));
 
         balance0 = IERC20(token0).balanceOf(token);
         balance1 = IERC20(token1).balanceOf(token);
         // totalSupply = pair.totalSupply();
         balanceOLA = (token0 == olas) ? balance0 : balance1;
         balanceDAI = (token0 == olas) ? balance1 : balance0;
-        console.log("AttackDeposit ## OLAS reserved after swap", balanceOLA);
-        console.log("AttackDeposit ## DAI reserved before swap", balanceDAI);
+        // console.log("AttackDeposit ## OLAS reserved after swap", balanceOLA);
+        // console.log("AttackDeposit ## DAI reserved before swap", balanceDAI);
 
-        IDepository(depository).depositOriginal(token, bid, amountTo, address(this));
-        //console.log("AttackDeposit ## payout", payout);
+        (payout, , ) = IDepository(depository).deposit(token, bid, amountTo, address(this));
         
         // DAI approve 
         IERC20(path[1]).approve(swapRouter, LARGE_APPROVAL);
@@ -112,78 +78,15 @@ contract AttackDeposit {
         path[0] = path[1];
         path[1] = olas;
         amounts = IRouter(swapRouter).swapExactTokensForTokens(IERC20(path[0]).balanceOf(address(this)), 0, path, address(this), block.timestamp + 3000);
-        console.log("balance OLAS in this contract after swap:",IERC20(olas).balanceOf(address(this)));
+        // console.log("balance OLAS in this contract after swap:", IERC20(olas).balanceOf(address(this)));
 
         balance0 = IERC20(token0).balanceOf(token);
         balance1 = IERC20(token1).balanceOf(token);
         // totalSupply = pair.totalSupply();
         balanceOLA = (token0 == olas) ? balance0 : balance1;
         balanceDAI = (token0 == olas) ? balance1 : balance0;
-        console.log("AttackDeposit ## OLAS reserved after swap", balanceOLA);
-        console.log("AttackDeposit ## DAI reserved before swap", balanceDAI);
-    }
-
-    // @dev emulate attack against deposit with slippage check
-    // @param depository Address of depository.
-    // @param token Address of pair
-    // @param olas Address of OLAS token
-    // @param bid number of bid
-    // @param amountTo amount LP for deposit.
-    // @param swapRouter uniswapV2 router address 
-    function attackDepositMustFail(address depository, address token, address olas, uint256 bid, uint256 amountTo, address swapRouter) external {
-        // Trying to deposit the amount that would result in an overflow payout for the LP supply
-        // await pairODAI.connect(deployer).approve(depository.address, LARGE_APPROVAL);
-        // depository.connect(deployer).deposit(pairODAI.address, bid, amountTo, deployer.address);
-        address[] memory path = new address[](2);
-        uint256[] memory amounts = new uint256[](2);
-
-        IERC20(token).approve(depository, LARGE_APPROVAL);
-        // IUniswapV2Pair pair = IUniswapV2Pair(address(token));
-        address token0 = IUniswapV2Pair(address(token)).token0();
-        address token1 = IUniswapV2Pair(address(token)).token1();
-        uint256 balance0 = IERC20(token0).balanceOf(token);
-        uint256 balance1 = IERC20(token1).balanceOf(token);
-        // uint256 totalSupply = pair.totalSupply();
-        uint256 balanceOLA = (token0 == olas) ? balance0 : balance1;
-        uint256 balanceDAI = (token0 == olas) ? balance1 : balance0;
-        console.log("AttackDeposit ## OLAS reserved before deposi", balanceOLA);
-        console.log("AttackDeposit ## DAI reserved before deposi", balanceDAI);
-        // uint256 amountToSwap = IERC20(olas).balanceOf(address(this));
-
-        path[0] = (token0 == olas) ? token0 : token1;
-        path[1] = (token0 == olas) ? token1 : token0;
-
-        console.log("balance OLAS in this contract before swap {pseudo flash loan OLAS}:",IERC20(olas).balanceOf(address(this)));
-        IERC20(olas).approve(swapRouter, LARGE_APPROVAL);
-        amounts = IRouter(swapRouter).swapExactTokensForTokens(IERC20(olas).balanceOf(address(this)), 0, path, address(this), block.timestamp + 3000);
-        console.log("balance OLAS in this contract after swap:",IERC20(olas).balanceOf(address(this)));
-
-        balance0 = IERC20(token0).balanceOf(token);
-        balance1 = IERC20(token1).balanceOf(token);
-        // totalSupply = pair.totalSupply();
-        balanceOLA = (token0 == olas) ? balance0 : balance1;
-        balanceDAI = (token0 == olas) ? balance1 : balance0;
-        console.log("AttackDeposit ## OLAS reserved after swap", balanceOLA);
-        console.log("AttackDeposit ## DAI reserved before swap", balanceDAI);
-
-        IDepository(depository).deposit(token, bid, amountTo, address(this));
-        //console.log("AttackDeposit ## payout", payout);
-        
-        // DAI approve 
-        IERC20(path[1]).approve(swapRouter, LARGE_APPROVAL);
-        // swap back
-        path[0] = path[1];
-        path[1] = olas;
-        amounts = IRouter(swapRouter).swapExactTokensForTokens(IERC20(path[0]).balanceOf(address(this)), 0, path, address(this), block.timestamp + 3000);
-        console.log("balance OLAS in this contract after swap:",IERC20(olas).balanceOf(address(this)));
-
-        balance0 = IERC20(token0).balanceOf(token);
-        balance1 = IERC20(token1).balanceOf(token);
-        // totalSupply = pair.totalSupply();
-        balanceOLA = (token0 == olas) ? balance0 : balance1;
-        balanceDAI = (token0 == olas) ? balance1 : balance0;
-        console.log("AttackDeposit ## OLAS reserved after swap", balanceOLA);
-        console.log("AttackDeposit ## DAI reserved before swap", balanceDAI);
+        // console.log("AttackDeposit ## OLAS reserved after swap", balanceOLA);
+        // console.log("AttackDeposit ## DAI reserved before swap", balanceDAI);
     }    
 
 }

--- a/test/Depository.js
+++ b/test/Depository.js
@@ -11,7 +11,6 @@ describe("Depository LP", async () => {
     const initialMint = "4" + "0".repeat(4) + decimals;
 
     const AddressZero = "0x" + "0".repeat(40);
-    const E18 = "1" + "0".repeat(18);
 
     let deployer, alice, bob;
     let erc20Token;
@@ -29,7 +28,7 @@ describe("Depository LP", async () => {
     let tokenomics;
     let epochLen = 100;
 
-    // 5,000
+    // 2,000
     let supplyProductOLA =  "2" + "0".repeat(3) + decimals;
     let pseudoFlashLoan = "2"  + "0".repeat(2) + decimals;
 
@@ -40,8 +39,6 @@ describe("Depository LP", async () => {
     var bid = 0;
     let first;
     let id;
-    // 200 == 2%
-    let slippage = 200;
 
     let attackDepositFactory;
     let attackDeposit;
@@ -72,7 +69,7 @@ describe("Depository LP", async () => {
         await tokenomics.changeRewardFraction(50, 33, 17, 0, 0);
         // Change to the correct depository address
         depository = await depositoryFactory.deploy(olas.address, treasury.address, tokenomics.address);
-        // Deploy Attack example    
+        // Deploy Attack example
         attackDeposit = await attackDepositFactory.deploy();
 
         // Change to the correct addresses
@@ -108,18 +105,18 @@ describe("Depository LP", async () => {
         //const actual_bytecode1 = json["bytecode"];
         //const COMPUTED_INIT_CODE_HASH1 = ethers.utils.keccak256(actual_bytecode1);
         //console.log("init hash:", COMPUTED_INIT_CODE_HASH1, "in UniswapV2Library :: hash:0xe9d807835bf1c75fb519759197ec594400ca78aa1d4b77743b1de676f24f8103");
-           
+
         //const pairODAItxReceipt = await factory.createPair(olas.address, dai.address);
         await factory.createPair(olas.address, dai.address);
         // const pairODAIdata = factory.interface.decodeFunctionData("createPair", pairODAItxReceipt.data);
-        // console.log("olas[%s]:DAI[%s] pool", pairODAIdata[0], pairODAIdata[1]); 
+        // console.log("olas[%s]:DAI[%s] pool", pairODAIdata[0], pairODAIdata[1]);
         let pairAddress = await factory.allPairs(0);
         // console.log("olas - DAI address:", pairAddress);
         pairODAI = await ethers.getContractAt("UniswapV2Pair", pairAddress);
         // let reserves = await pairODAI.getReserves();
         // console.log("olas - DAI reserves:", reserves.toString());
         // console.log("balance dai for deployer:",(await dai.balanceOf(deployer.address)));
-        
+
         // Add liquidity
         //const amountOLAS = await olas.balanceOf(deployer.address);
         const amountOLAS = "5"  + "0".repeat(3) + decimals;
@@ -157,12 +154,7 @@ describe("Depository LP", async () => {
 
         await treasury.enableToken(pairODAI.address);
 
-        await depository.create(
-            pairODAI.address,
-            supplyProductOLA,
-            vesting,
-            slippage
-        );
+        await depository.create(pairODAI.address, supplyProductOLA, vesting);
 
         const block = await ethers.provider.getBlock("latest");
         conclusion = block.timestamp + timeToConclusion;
@@ -184,12 +176,7 @@ describe("Depository LP", async () => {
 
     it("should return IDs of all products", async () => {
         // create a second bond
-        await depository.create(
-            pairODAI.address,
-            supplyProductOLA,
-            vesting,
-            slippage
-        );
+        await depository.create(pairODAI.address, supplyProductOLA, vesting);
         let [first, second] = await depository.getActiveProductsForToken(pairODAI.address);
         expect(Number(first)).to.equal(0);
         expect(Number(second)).to.equal(1);
@@ -197,12 +184,7 @@ describe("Depository LP", async () => {
 
     it("should update IDs of products", async () => {
         // create a second bond
-        await depository.create(
-            pairODAI.address,
-            supplyProductOLA,
-            vesting,
-            slippage
-        );
+        await depository.create(pairODAI.address, supplyProductOLA, vesting);
         // close the first bond
         await depository.close(pairODAI.address, 0);
         [first] = await depository.getActiveProductsForToken(pairODAI.address);
@@ -236,92 +218,7 @@ describe("Depository LP", async () => {
     });
 
     it("should not allow a deposit greater than max payout", async () => {
-        const amountTo = new ethers.BigNumber.from(await pairODAI.balanceOf(bob.address));
-        // Transfer all LP tokens back to deployer
-        await pairODAI.connect(bob).transfer(deployer.address, amountTo);
         const amount = (await pairODAI.balanceOf(deployer.address));
-        //console.log("LP token in:",amount);
-
-        const totalSupply = (await pairODAI.totalSupply());
-        // Calculate payout based on the amount of LP
-        const token0address = (await pairODAI.token0());
-        const token1address = (await pairODAI.token1());
-        const token0 = await ethers.getContractAt("ERC20Token", token0address);
-        const token1 = await ethers.getContractAt("ERC20Token", token1address);
-
-        // Get the balances of tokens in LP
-        let balance0 = (await token0.balanceOf(pairODAI.address));
-        let balance1 = (await token1.balanceOf(pairODAI.address));
-        //console.log("token0",token0.address);
-        //console.log("token1",token1.address);
-        //console.log("balance0",balance0);
-        //console.log("balance1",balance1);
-        //console.log("olas token",olas.address);
-        //console.log("totalSupply LP",totalSupply);
-
-        // Token fractions based on the LP tokens amount and total supply
-        const amount0 = ethers.BigNumber.from(amount).mul(balance0).div(totalSupply);
-        const amount1 = ethers.BigNumber.from(amount).mul(balance1).div(totalSupply);
-        //console.log("token0 amount ref LP",amount0);
-        //console.log("token1 amount ref LP",amount1);
-
-        // This is equivalent to removing the liquidity
-        // Get the initial OLAS token amounts
-        // uint256 amountOLAS = (token0 == olas) ? amount0 : amount1;
-        // uint256 amountPairForOLAS = (token0 == olas) ? amount1 : amount0;
-        let amountOLAS;
-        let amountPairForOLAS;
-        let reserveIn;
-        let reserveOut;
-        let amountIn;
-        if(token1.address == olas.address) {
-            amountOLAS = amount1;
-            amountPairForOLAS = amount0;
-        } else {
-            amountOLAS = amount0;
-            amountPairForOLAS = amount1;
-        }
-        balance0 = balance0.sub(amount0);
-        balance1 = balance1.sub(amount1);
-        //console.log("after remove liquidity balance0",balance0);
-        //console.log("after remove liquidity balance1",balance1);
-
-        // This is the equivalent of a swap operation to calculate additional OLAS
-        if(token1.address == olas.address) {
-            reserveIn = balance0;
-            reserveOut = balance1;
-            amountIn = amountPairForOLAS;
-        } else {
-            reserveIn = balance1;
-            reserveOut = balance0;
-            amountIn = amountPairForOLAS;
-        }
-        //console.log("amountIn",amountIn);
-        // amountOLAS = amountOLAS + getAmountOut(amountPairForOLAS, reserveIn, reserveOut);
-
-        // We use this tutorial to correctly calculate the in-out amounts:
-        // https://ethereum.org/en/developers/tutorials/uniswap-v2-annotated-code/#why-v2
-        const amountInWithFee = amountIn.mul(997);
-        const numerator = amountInWithFee.div(reserveOut);
-        const denominator = (reserveIn.mul(1000)).add(amountInWithFee);
-        const amountOut = numerator.div(denominator);
-        amountOLAS = amountOLAS.add(amountOut);
-        //console.log("amountInWithFee",amountInWithFee);
-        //console.log("numerator",numerator);
-        //console.log("denominator",denominator);
-        //console.log("delta amountOut:",amountOut);
-        //console.log("sutotal amountOLAS:",amountOLAS);
-        const payout = await tokenomics.calculatePayoutFromLP(pairODAI.address, amount);
-
-        // Gets DF
-        let lastEpoch = await tokenomics.epochCounter() - 1;
-        const df = await tokenomics.getDF(lastEpoch);
-
-        // Payouts with direct calculation and via DF must be equal
-        expect(amountOLAS.mul(df).div(E18)).to.equal(payout);
-        //console.log("payout direclty", payout);
-        //console.log("payout via df", amountOLAS.mul(df).div(E18));
-        //console.log("supply product",supplyProductOLA);
 
         // Trying to deposit the amount that would result in an overflow payout for the LP supply
         await pairODAI.connect(deployer).approve(depository.address, LARGE_APPROVAL);
@@ -331,251 +228,28 @@ describe("Depository LP", async () => {
         ).to.be.revertedWithCustomError(depository, "ProductSupplyLow");
     });
 
-    it("should allow deposit via smart-contract", async () => {
+    it("proof of protect against attack via smart-contract use deposit", async () => {
         const amountTo = new ethers.BigNumber.from(await pairODAI.balanceOf(bob.address));
         // Transfer all LP tokens back to deployer
         // await pairODAI.connect(bob).transfer(deployer.address, amountTo);
         await pairODAI.connect(bob).transfer(attackDeposit.address, amountTo);
-        //const amount = (await pairODAI.balanceOf(deployer.address));
-
-        const totalSupply = (await pairODAI.totalSupply());
-        // Calculate payout based on the amount of LP
-        const token0address = (await pairODAI.token0());
-        const token1address = (await pairODAI.token1());
-        const token0 = await ethers.getContractAt("ERC20Token", token0address);
-        const token1 = await ethers.getContractAt("ERC20Token", token1address);
-
-        // Get the balances of tokens in LP
-        let balance0 = (await token0.balanceOf(pairODAI.address));
-        let balance1 = (await token1.balanceOf(pairODAI.address));
-
-        // Token fractions based on the LP tokens amount and total supply
-        const amount0 = ethers.BigNumber.from(amountTo).mul(balance0).div(totalSupply);
-        const amount1 = ethers.BigNumber.from(amountTo).mul(balance1).div(totalSupply);
-
-        // This is equivalent to removing the liquidity
-        // Get the initial OLAS token amounts
-        // uint256 amountOLAS = (token0 == olas) ? amount0 : amount1;
-        // uint256 amountPairForOLAS = (token0 == olas) ? amount1 : amount0;
-        let amountOLAS;
-        let amountPairForOLAS;
-        let reserveIn;
-        let reserveOut;
-        let amountIn;
-        if(token1.address == olas.address) {
-            amountOLAS = amount1;
-            amountPairForOLAS = amount0;
-        } else {
-            amountOLAS = amount0;
-            amountPairForOLAS = amount1;
-        }
-        balance0 = balance0.sub(amount0);
-        balance1 = balance1.sub(amount1);
-
-        // This is the equivalent of a swap operation to calculate additional OLAS
-        if(token1.address == olas.address) {
-            reserveIn = balance0;
-            reserveOut = balance1;
-            amountIn = amountPairForOLAS;
-        } else {
-            reserveIn = balance1;
-            reserveOut = balance0;
-            amountIn = amountPairForOLAS;
-        }
-        //console.log("amountIn",amountIn);
-        // amountOLAS = amountOLAS + getAmountOut(amountPairForOLAS, reserveIn, reserveOut);
-
-        // We use this tutorial to correctly calculate the in-out amounts:
-        // https://ethereum.org/en/developers/tutorials/uniswap-v2-annotated-code/#why-v2
-        const amountInWithFee = amountIn.mul(997);
-        const numerator = amountInWithFee.div(reserveOut);
-        const denominator = (reserveIn.mul(1000)).add(amountInWithFee);
-        const amountOut = numerator.div(denominator);
-        amountOLAS = amountOLAS.add(amountOut);
-        const payout = await tokenomics.calculatePayoutFromLP(pairODAI.address, amountTo);
-
-        // Gets DF
-        let lastEpoch = await tokenomics.epochCounter() - 1;
-        const df = await tokenomics.getDF(lastEpoch);
-
-        // Payouts with direct calculation and via DF must be equal
-        expect(amountOLAS.mul(df).div(E18)).to.equal(payout);
 
         // Trying to deposit the amount that would result in an overflow payout for the LP supply
         //await pairODAI.connect(deployer).approve(depository.address, LARGE_APPROVAL);
         //depository.connect(deployer).deposit(pairODAI.address, bid, amountTo, deployer.address);
-        await attackDeposit.normalDeposit(depository.address, pairODAI.address, olas.address, bid, amountTo);
-        expect(Array(await depository.getPendingBonds(attackDeposit.address)).length).to.equal(1);
+        const payout = await attackDeposit.callStatic.flashAttackDepositImmune(depository.address, pairODAI.address, olas.address,
+            bid, amountTo, router.address);
+
+        // Try to attack via flash loan
+        await attackDeposit.flashAttackDepositImmune(depository.address, pairODAI.address, olas.address,
+            bid, amountTo, router.address);
+
+        // Check that the flash attack did not do anything but obtained the same bond as everybody
         const res = await depository.getBondStatus(attackDeposit.address, 0);
-        // 1250 * 1.5 = 1875 * e18 =  1.875 * e21
+        expect(res.payout).to.equal(payout);
+
+        // We know that the payout for any account under these parameters must be 1.875 * e21
         expect(Number(res.payout)).to.equal(1.875e+21);
-    });
-
-    it("proof of attack via smart-contract use depositOriginal", async () => {
-        const amountTo = new ethers.BigNumber.from(await pairODAI.balanceOf(bob.address));
-        // Transfer all LP tokens back to deployer
-        // await pairODAI.connect(bob).transfer(deployer.address, amountTo);
-        await pairODAI.connect(bob).transfer(attackDeposit.address, amountTo);
-        //const amount = (await pairODAI.balanceOf(deployer.address));
-        console.log("LP token in:",amountTo);
-
-        const totalSupply = (await pairODAI.totalSupply());
-        // Calculate payout based on the amount of LP
-        const token0address = (await pairODAI.token0());
-        const token1address = (await pairODAI.token1());
-        const token0 = await ethers.getContractAt("ERC20Token", token0address);
-        const token1 = await ethers.getContractAt("ERC20Token", token1address);
-
-        // Get the balances of tokens in LP
-        let balance0 = (await token0.balanceOf(pairODAI.address));
-        let balance1 = (await token1.balanceOf(pairODAI.address));
-
-        // Token fractions based on the LP tokens amount and total supply
-        const amount0 = ethers.BigNumber.from(amountTo).mul(balance0).div(totalSupply);
-        const amount1 = ethers.BigNumber.from(amountTo).mul(balance1).div(totalSupply);
-
-        // This is equivalent to removing the liquidity
-        // Get the initial OLAS token amounts
-        // uint256 amountOLAS = (token0 == olas) ? amount0 : amount1;
-        // uint256 amountPairForOLAS = (token0 == olas) ? amount1 : amount0;
-        let amountOLAS;
-        let amountPairForOLAS;
-        let reserveIn;
-        let reserveOut;
-        let amountIn;
-        if(token1.address == olas.address) {
-            amountOLAS = amount1;
-            amountPairForOLAS = amount0;
-        } else {
-            amountOLAS = amount0;
-            amountPairForOLAS = amount1;
-        }
-        balance0 = balance0.sub(amount0);
-        balance1 = balance1.sub(amount1);
-
-        // This is the equivalent of a swap operation to calculate additional OLAS
-        if(token1.address == olas.address) {
-            reserveIn = balance0;
-            reserveOut = balance1;
-            amountIn = amountPairForOLAS;
-        } else {
-            reserveIn = balance1;
-            reserveOut = balance0;
-            amountIn = amountPairForOLAS;
-        }
-        //console.log("amountIn",amountIn);
-        // amountOLAS = amountOLAS + getAmountOut(amountPairForOLAS, reserveIn, reserveOut);
-
-        // We use this tutorial to correctly calculate the in-out amounts:
-        // https://ethereum.org/en/developers/tutorials/uniswap-v2-annotated-code/#why-v2
-        const amountInWithFee = amountIn.mul(997);
-        const numerator = amountInWithFee.div(reserveOut);
-        const denominator = (reserveIn.mul(1000)).add(amountInWithFee);
-        const amountOut = numerator.div(denominator);
-        amountOLAS = amountOLAS.add(amountOut);
-        const payout = await tokenomics.calculatePayoutFromLP(pairODAI.address, amountTo);
-
-        // Gets DF
-        let lastEpoch = await tokenomics.epochCounter() - 1;
-        const df = await tokenomics.getDF(lastEpoch);
-
-        // Payouts with direct calculation and via DF must be equal
-        expect(amountOLAS.mul(df).div(E18)).to.equal(payout);
-        console.log("payout direclty", payout);
-        console.log("payout via df", amountOLAS.mul(df).div(E18));
-        console.log("supply product",supplyProductOLA);
-
-        // Trying to deposit the amount that would result in an overflow payout for the LP supply
-        //await pairODAI.connect(deployer).approve(depository.address, LARGE_APPROVAL);
-        //depository.connect(deployer).deposit(pairODAI.address, bid, amountTo, deployer.address);
-        await attackDeposit.attackDepositMustSuccess(depository.address, pairODAI.address, olas.address, bid, amountTo, router.address);
-        expect(Array(await depository.getPendingBonds(attackDeposit.address)).length).to.equal(1);
-        const res = await depository.getBondStatus(attackDeposit.address, 0);
-        console.log(res);
-        // 1.95e21 proof of attack > 1.875e21
-        expect(Number(res.payout)).to.equal(1.95e+21);
-    });
-
-    it("proof of protect against attack via smart-contract use deposit with slippage check", async () => {
-        const amountTo = new ethers.BigNumber.from(await pairODAI.balanceOf(bob.address));
-        // Transfer all LP tokens back to deployer
-        // await pairODAI.connect(bob).transfer(deployer.address, amountTo);
-        await pairODAI.connect(bob).transfer(attackDeposit.address, amountTo);
-        //const amount = (await pairODAI.balanceOf(deployer.address));
-        console.log("LP token in:",amountTo);
-
-        const totalSupply = (await pairODAI.totalSupply());
-        // Calculate payout based on the amount of LP
-        const token0address = (await pairODAI.token0());
-        const token1address = (await pairODAI.token1());
-        const token0 = await ethers.getContractAt("ERC20Token", token0address);
-        const token1 = await ethers.getContractAt("ERC20Token", token1address);
-
-        // Get the balances of tokens in LP
-        let balance0 = (await token0.balanceOf(pairODAI.address));
-        let balance1 = (await token1.balanceOf(pairODAI.address));
-
-        // Token fractions based on the LP tokens amount and total supply
-        const amount0 = ethers.BigNumber.from(amountTo).mul(balance0).div(totalSupply);
-        const amount1 = ethers.BigNumber.from(amountTo).mul(balance1).div(totalSupply);
-
-        // This is equivalent to removing the liquidity
-        // Get the initial OLAS token amounts
-        // uint256 amountOLAS = (token0 == olas) ? amount0 : amount1;
-        // uint256 amountPairForOLAS = (token0 == olas) ? amount1 : amount0;
-        let amountOLAS;
-        let amountPairForOLAS;
-        let reserveIn;
-        let reserveOut;
-        let amountIn;
-        if(token1.address == olas.address) {
-            amountOLAS = amount1;
-            amountPairForOLAS = amount0;
-        } else {
-            amountOLAS = amount0;
-            amountPairForOLAS = amount1;
-        }
-        balance0 = balance0.sub(amount0);
-        balance1 = balance1.sub(amount1);
-
-        // This is the equivalent of a swap operation to calculate additional OLAS
-        if(token1.address == olas.address) {
-            reserveIn = balance0;
-            reserveOut = balance1;
-            amountIn = amountPairForOLAS;
-        } else {
-            reserveIn = balance1;
-            reserveOut = balance0;
-            amountIn = amountPairForOLAS;
-        }
-        //console.log("amountIn",amountIn);
-        // amountOLAS = amountOLAS + getAmountOut(amountPairForOLAS, reserveIn, reserveOut);
-
-        // We use this tutorial to correctly calculate the in-out amounts:
-        // https://ethereum.org/en/developers/tutorials/uniswap-v2-annotated-code/#why-v2
-        const amountInWithFee = amountIn.mul(997);
-        const numerator = amountInWithFee.div(reserveOut);
-        const denominator = (reserveIn.mul(1000)).add(amountInWithFee);
-        const amountOut = numerator.div(denominator);
-        amountOLAS = amountOLAS.add(amountOut);
-        const payout = await tokenomics.calculatePayoutFromLP(pairODAI.address, amountTo);
-
-        // Gets DF
-        let lastEpoch = await tokenomics.epochCounter() - 1;
-        const df = await tokenomics.getDF(lastEpoch);
-
-        // Payouts with direct calculation and via DF must be equal
-        expect(amountOLAS.mul(df).div(E18)).to.equal(payout);
-        console.log("payout direclty", payout);
-        console.log("payout via df", amountOLAS.mul(df).div(E18));
-        console.log("supply product",supplyProductOLA);
-
-        // Trying to deposit the amount that would result in an overflow payout for the LP supply
-        //await pairODAI.connect(deployer).approve(depository.address, LARGE_APPROVAL);
-        //depository.connect(deployer).deposit(pairODAI.address, bid, amountTo, deployer.address);
-        await expect(
-            attackDeposit.attackDepositMustFail(depository.address, pairODAI.address, olas.address, bid, amountTo, router.address)
-        ).to.be.revertedWithCustomError(depository, "ProductSlippageOverflow");
     });
 
     it("should not redeem before vested", async () => {


### PR DESCRIPTION
### Making stable LP token pricing for bonding to avoid slippage predicting and flash loan attacks.
Here we are suggesting the version of the LP pricing calculation that does not require to calculate slippage in order to avoid huge swings in price changes.

Mathematically this approach is the same as if we picked the most optimal slippage for bonding every time we create a bonding product. However, using on-chain tools would require to put additional efforts into that.

Our approach compensate the need of calculating the slippage by locking the LP price when the bonding product is created. After that the swings in slippage would be identical to the discount factor minimization coefficient. In other words, the bonding program becomes below profitable even with the discount factor applied if the OLAS price drops below the initial value multiplied to the discount factor.

This scenario would be equal to calculation of the optimal slippage, and since the slippage would be also broken, the deposit would never happen. Using our suggested approach, DAO-s / users can verify the profits of bonding themselves by getting the OLAS payout value from the bonding product parameter. If that value is below the discount factor profitability, they would not deposit into bonding.

Here's the condition that suggests the bonding product profitability:
`df*r0 / L0 >= r(i) / L(i)`, where `r0` is the reserves of OLAS tokens during the bonding product creation, `L0` - total supply of the LP token in the moment of product creation, and `i` is any moment during the bonding product existence.
However, instead of slippage blocking the possibility of deposits, participating accounts can decide for themselves if depositing to the bonding product is needed / profitable for them.

The big benefit of such an approach is that the (virtual) LP price calculation in the `deposit()` function becomes absolutely immune to any pool attacks since the price does not depend on the pools state during the bonding product existence.

The attack test proves that the attacker gets as much of the OLAS tokens during bonding as any other account(s) that do not mean any harm.