### PR TITLE
refactor: fixing inflation calculation and how it drives top-ups

### DIFF
--- a/contracts/Depository.sol
+++ b/contracts/Depository.sol
@@ -31,7 +31,7 @@ import "./interfaces/ITreasury.sol";
 contract Depository is GenericTokenomics {
     event CreateBond(address indexed token, uint256 productId, uint256 amountOLAS, uint256 tokenAmount);
     event CreateProduct(address indexed token, uint256 productId, uint256 supply);
-    event TerminateProduct(address indexed token, uint256 productId);
+    event CloseProduct(address indexed token, uint256 productId);
 
     // The size of the struct is 96 + 32 * 2 + 8 = 168 bits (1 full slot)
     struct Bond {
@@ -109,6 +109,7 @@ contract Depository is GenericTokenomics {
         Product storage product = mapTokenProducts[token][productId];
 
         // Check for the product expiry
+        // Note that if the token or productId are invalid, the expiry will be zero by default and revert the function
         expiry = product.expiry;
         if (expiry < block.timestamp) {
             revert ProductExpired(token, productId, product.expiry, block.timestamp);
@@ -132,10 +133,8 @@ contract Depository is GenericTokenomics {
         mapUserBonds[user].push(Bond(payout, expiry, productId, false));
         emit CreateBond(token, productId, payout, tokenAmount);
 
-        // Take into account this bond in current epoch
-        ITokenomics(tokenomics).updateEpochBond(payout);
-
-        // Uniswap allowance implementation does not revert with the accurate message, check before SafeMath is engaged
+        // TODO All the transfer-related routines below can be moved to the treasury side without the need to receive funds by depository first?
+        // Uniswap allowance implementation does not revert with the accurate message, check before the transfer is engaged
         if (IERC20(product.token).allowance(msg.sender, address(this)) < tokenAmount) {
             revert InsufficientAllowance(IERC20(product.token).allowance((msg.sender), address(this)), tokenAmount);
         }
@@ -232,7 +231,7 @@ contract Depository is GenericTokenomics {
         }
 
         // Check if the bond amount is beyond the limits
-        if (!ITokenomics(tokenomics).allowedNewBond(supply)) {
+        if (!ITokenomics(tokenomics).reserveAmountForBondProgram(supply)) {
             revert AmountLowerThan(ITokenomics(tokenomics).effectiveBond(), supply);
         }
 
@@ -254,6 +253,7 @@ contract Depository is GenericTokenomics {
         emit CreateProduct(token, productId, supply);
     }
 
+    // TODO Make this function callable by everybody, also from the redeem function
     /// @dev Close a bonding product.
     /// @param token Specified token.
     /// @param productId Product Id.
@@ -263,11 +263,18 @@ contract Depository is GenericTokenomics {
             revert OwnerOnly(msg.sender, owner);
         }
 
+        uint96 supply = mapTokenProducts[token][productId].supply;
+        // Refund unused OLAS supply from the program if not used completely
+        if (supply > 0) {
+            ITokenomics(tokenomics).refundFromBondProgram(supply);
+        }
+        // TODO Check if delete of the mapTokenProducts[token][productId] is better
         mapTokenProducts[token][productId].supply = 0;
         
-        emit TerminateProduct(token, productId);
+        emit CloseProduct(token, productId);
     }
 
+    // TODO Optimize for gas usage
     /// @dev Gets activity information about a given product.
     /// @param productId Product Id.
     /// @return status True if the product is active.

--- a/contracts/GenericTokenomics.sol
+++ b/contracts/GenericTokenomics.sol
@@ -37,7 +37,7 @@ abstract contract GenericTokenomics is IErrorsTokenomics {
     // Dispenser contract address
     address public dispenser;
     // Reentrancy lock
-    uint256 internal _locked = 1;
+    uint8 internal _locked = 1;
 
     /// @dev Generic Tokenomics constructor.
     /// @param _olas OLAS token address.

--- a/contracts/Tokenomics.sol
+++ b/contracts/Tokenomics.sol
@@ -10,6 +10,7 @@ import "./interfaces/IToken.sol";
 import "./interfaces/ITreasury.sol";
 import "./interfaces/IVotingEscrow.sol";
 
+
 /*
 * In this contract we consider both ETH and OLAS tokens.
 * For ETH tokens, there are currently about 121 million tokens.
@@ -68,7 +69,7 @@ struct PointUnits {
 }
 
 // Structure for tokenomics
-// The size of the struct is 512 * 2 + 64 + 32 + 96 * 6 + 32 * 2 = 256 * 4 + 128 (5 full slots)
+// The size of the struct is 512 * 2 + 96 * 5 + 64 + 32 * 4 = 256 * 6 + 128 + 32 (7 full slots)
 struct PointEcomonics {
     // UCFc
     PointUnits ucfc;
@@ -96,26 +97,25 @@ struct PointEcomonics {
     // Number of valuable devs can be paid per units of capital per epoch
     // This number cannot be practically bigger than the total number of supported units
     uint32 devsPerCapital;
-    // Block number
+    // Epoch end block number
     // With the current number of seconds per block and the current block number, 2^32 - 1 is enough for the next 1600+ years
-    uint32 blockNumber;
-    // Timestamp
+    uint32 endBlockNumber;
+    // Epoch end timestamp
     // 2^32 - 1 gives 136+ years counted in seconds starting from the year 1970, which is safe until the year of 2106
-    uint32 epochTime;
+    uint32 endTime;
 }
 
 /// @title Tokenomics - Smart contract for store/interface for key tokenomics params
 /// @author AL
 /// @author Aleksandr Kuperman - <aleksandr.kuperman@valory.xyz>
 contract Tokenomics is TokenomicsConstants, GenericTokenomics {
-    // TODO Just substitute with 10**18?
     using PRBMathSD59x18 for *;
 
-    event EpochLengthUpdated(uint32 epochLength);
-    event TokenomicsParametersUpdates(uint16 ucfcWeight, uint16 ucfaWeight, uint16 componentWeight, uint16 agentWeight,
-        uint32 devsPerCapital, uint64 epsilonRate, uint96 maxBond, uint32 epochLen, bool bondAutoControl);
-    event RewardFractionsUpdated(uint8 stakerFraction, uint8 componentFraction, uint8 agentFraction,
-        uint8 topUpOwnerFraction, uint8 topUpStakerFraction);
+    event EpochLengthUpdated(uint256 epochLength);
+    event TokenomicsParametersUpdates(uint256 ucfcWeight, uint256 ucfaWeight, uint256 componentWeight,
+        uint256 agentWeight, uint256 devsPerCapital, uint256 epsilonRate, uint256 epochLen);
+    event IncentiveFractionsUpdated(uint256 stakerFraction, uint256 componentFraction, uint256 agentFraction,
+        uint256 maxBondFraction, uint256 topUpOwnerFraction);
     event ComponentRegistryUpdated(address indexed componentRegistry);
     event AgentRegistryUpdated(address indexed agentRegistry);
     event ServiceRegistryUpdated(address indexed serviceRegistry);
@@ -124,10 +124,9 @@ contract Tokenomics is TokenomicsConstants, GenericTokenomics {
     // Voting Escrow address
     address public immutable ve;
 
-    // TODO Review max bond per epoch depending on the number of epochs per year, and the updated inflation schedule
-    // ~150k of OLAS tokens per epoch (less than the max cap of 22 million during 1st year, the bonding fraction is 40%)
+    // Max bond per epoch: calculated as a fraction from the OLAS inflation parameter
     // After 10 years, the OLAS inflation rate is 2% per year. It would take 220+ years to reach 2^96 - 1
-    uint96 public maxBond = 150_000 * 1e18;
+    uint96 public maxBond;
     // Default epsilon rate that contributes to the interest rate: 10% or 0.1
     // We assume that for the IDF calculation epsilonRate must be lower than 17 (with 18 decimals)
     // (2^64 - 1) / 10^18 > 18, however IDF = 1 + epsilonRate, thus we limit epsilonRate by 17 with 18 decimals at most
@@ -143,10 +142,9 @@ contract Tokenomics is TokenomicsConstants, GenericTokenomics {
     // This number cannot be practically bigger than the total number of supported units
     uint32 public devsPerCapital = 1;
 
-    // Bond per epoch
-    // This number cannot be practically bigger than the inflation remainder of OLAS
-    uint96 public bondPerEpoch;
-    // // Total service donation per epoch: sum(r(s))
+    // Inflation amount per second
+    uint96 public inflationPerSecond;
+    // Total service donation per epoch: sum(r(s))
     // Even if the ETH inflation rate is 5% per year, it would take 130+ years to reach 2^96 - 1 of ETH total supply
     uint96 public epochServiceDonationETH;
     // TODO Check if ucfc(a)Weight and componentWeight / agentWeight are the same
@@ -161,9 +159,10 @@ contract Tokenomics is TokenomicsConstants, GenericTokenomics {
 
     // Component Registry
     address public componentRegistry;
-    // MaxBond(e) - sum(BondingProgram) over all epochs: accumulates leftovers from previous epochs
-    // This number cannot be practically bigger than the maxBond
-    uint96 public effectiveBond = maxBond;
+    // effectiveBond = sum(MaxBond(e)) - sum(BondingProgram) over all epochs: accumulates leftovers from previous epochs
+    // Effective bond is updated before the start of the next epoch such that the bonding limits are accounted for
+    // This number cannot be practically bigger than the inflation remainder of OLAS
+    uint96 public effectiveBond;
 
     // Agent Registry
     address public agentRegistry;
@@ -173,20 +172,18 @@ contract Tokenomics is TokenomicsConstants, GenericTokenomics {
     uint8 public stakerFraction = 50;
     uint8 public componentFraction = 33;
     uint8 public agentFraction = 17;
-    // Top-up of OLAS and bonding parameters (in percentage)
+    // maxBond and top-ups of OLAS parameters (in percentage)
     // Each of these numbers cannot be practically bigger than 100 as they sum up to 100%
+    uint8 public maxBondFraction = 40;
     uint8 public topUpOwnerFraction = 40;
-    uint8 public topUpStakerFraction = 20;
     // Current year number
     // This number is enough for the next 255 years
-    uint8 currentYear;
-    // Manual or auto control of max bond
-    bool public bondAutoControl;
+    uint8 public currentYear;
+    // maxBond-related parameter change locker
+    uint8 public lockMaxBond = 1;
 
     // Service Registry
     address public serviceRegistry;
-    // Inflation amount per second
-    uint96 public inflationPerSecond;
 
     // Map of service Ids and their amounts in current epoch
     mapping(uint256 => uint256) public mapServiceAmounts;
@@ -227,8 +224,42 @@ contract Tokenomics is TokenomicsConstants, GenericTokenomics {
         agentRegistry = _agentRegistry;
         serviceRegistry = _serviceRegistry;
 
-        // Calculating initial inflation per second derived from the zero year inflation amount
-        inflationPerSecond = uint96(22_113_000_0e17 / zeroYearSecondsLeft);
+        // Calculating initial inflation per second: (mintable OLAS from inflationAmounts[0]) / (seconds left in a year)
+        uint256 _inflationPerSecond = 22_113_000_0e17 / zeroYearSecondsLeft;
+        inflationPerSecond = uint96(_inflationPerSecond);
+
+        // Calculate initial effectiveBond based on the maxBond during the first epoch
+        uint256 _maxBond = _inflationPerSecond * _epochLen * maxBondFraction / 100;
+        maxBond = uint96(_maxBond);
+        effectiveBond = uint96(_maxBond);
+
+        // The initial epoch start time is the end time of the zero epoch
+        mapEpochEconomics[0].endTime = uint32(block.timestamp);
+    }
+
+    /// @dev Checks if the maxBond update is within allowed limits of the effectiveBond, and adjusts maxBond and effectiveBond.
+    /// @param nextMaxBond Proposed next epoch maxBond.
+    function _adjustMaxBond(uint256 nextMaxBond) internal {
+        uint256 curMaxBond = maxBond;
+        uint256 curEffectiveBond = effectiveBond;
+        // If the new epochLen is shorter than the current one, the current maxBond is bigger than the proposed one
+        if (curMaxBond > nextMaxBond) {
+            // Get the difference of the maxBond
+            uint256 delta = curMaxBond - nextMaxBond;
+            // Update the value for the effectiveBond if there is room for it
+            if (curEffectiveBond > delta) {
+                curEffectiveBond -= delta;
+            } else {
+                // Otherwise effectiveBond cannot be reduced further, and the current epochLen cannot be shortened
+                revert RejectMaxBondAdjustment(curEffectiveBond, delta);
+            }
+        } else {
+            // The new epochLen is longer than the current one, and thus we must add the difference to the effectiveBond
+            curEffectiveBond += nextMaxBond - curMaxBond;
+        }
+        // Update maxBond and effectiveBond based on their calculations
+        maxBond = uint96(nextMaxBond);
+        effectiveBond = uint96(curEffectiveBond);
     }
 
     /// @dev Changes tokenomics parameters.
@@ -238,9 +269,7 @@ contract Tokenomics is TokenomicsConstants, GenericTokenomics {
     /// @param _agentWeight Agent weight for new valuable code.
     /// @param _devsPerCapital Number of valuable devs can be paid per units of capital per epoch.
     /// @param _epsilonRate Epsilon rate that contributes to the interest rate value.
-    /// @param _maxBond MaxBond OLAS, 18 decimals.
     /// @param _epochLen New epoch length.
-    /// @param _bondAutoControl True to enable auto-tuning of max bonding value depending on the OLAS remainder
     function changeTokenomicsParameters(
         uint16 _ucfcWeight,
         uint16 _ucfaWeight,
@@ -248,10 +277,9 @@ contract Tokenomics is TokenomicsConstants, GenericTokenomics {
         uint16 _agentWeight,
         uint32 _devsPerCapital,
         uint64 _epsilonRate,
-        uint96 _maxBond,
-        uint32 _epochLen,
-        bool _bondAutoControl
-    ) external {
+        uint32 _epochLen
+    ) external
+    {
         // Check for the contract ownership
         if (msg.sender != owner) {
             revert OwnerOnly(msg.sender, owner);
@@ -268,28 +296,54 @@ contract Tokenomics is TokenomicsConstants, GenericTokenomics {
         if (_epsilonRate < 17e18) {
             epsilonRate = _epsilonRate;
         }
-        // Take into account the change during the epoch
-        _adjustMaxBond(_maxBond);
-        epochLen = _epochLen;
-        bondAutoControl = _bondAutoControl;
+
+        // Check for the epochLen value to change
+        uint256 oldEpochLen = epochLen;
+        if (oldEpochLen != _epochLen) {
+            // Check if the year change is ongoing in the current epoch, and thus maxBond cannot be changed
+            if (lockMaxBond == 2) {
+                revert MaxBondUpdateLocked();
+            }
+
+            // Check if the bigger proposed length of the epoch end time results in a scenario when the year changes
+            if (_epochLen > oldEpochLen) {
+                // End time of the last epoch
+                uint256 lastEpochEndTime = mapEpochEconomics[epochCounter - 1].endTime;
+                // Actual year of the time when the epoch is going to finish with the proposed epoch length
+                uint256 numYears = (lastEpochEndTime + _epochLen - timeLaunch) / oneYear;
+                // Check if the year is going to change
+                if (numYears > currentYear) {
+                    revert MaxBondUpdateLocked();
+                }
+            }
+
+            // Calculate next maxBond based on the proposed epochLen
+            uint256 nextMaxBond = inflationPerSecond * maxBondFraction * _epochLen / 100;
+            // Adjust maxBond and effectiveBond, if they are within the allowed limits
+            _adjustMaxBond(nextMaxBond);
+
+            // Update the epochLen
+            epochLen = _epochLen;
+        }
 
         emit TokenomicsParametersUpdates(_ucfcWeight, _ucfaWeight, _componentWeight, _agentWeight, _devsPerCapital,
-            _epsilonRate, _maxBond, _epochLen, _bondAutoControl);
+            _epsilonRate, _epochLen);
     }
 
-    /// @dev Sets staking parameters in fractions of distributed rewards.
+    /// @dev Sets incentive parameter fractions.
     /// @param _stakerFraction Fraction for stakers.
     /// @param _componentFraction Fraction for component owners.
     /// @param _agentFraction Fraction for agent owners.
+    /// @param _maxBondFraction Fraction for the maxBond.
     /// @param _topUpOwnerFraction Fraction for OLAS top-up for component / agent owners.
-    /// @param _topUpStakerFraction Fraction for OLAS top-up for stakers.
-    function changeRewardFraction(
+    function changeIncentiveFractions(
         uint8 _stakerFraction,
         uint8 _componentFraction,
         uint8 _agentFraction,
-        uint8 _topUpOwnerFraction,
-        uint8 _topUpStakerFraction
-    ) external {
+        uint8 _maxBondFraction,
+        uint8 _topUpOwnerFraction
+    ) external
+    {
         // Check for the contract ownership
         if (msg.sender != owner) {
             revert OwnerOnly(msg.sender, owner);
@@ -301,18 +355,33 @@ contract Tokenomics is TokenomicsConstants, GenericTokenomics {
         }
 
         // Same check for OLAS-related fractions
-        if (_topUpOwnerFraction + _topUpStakerFraction > 100) {
-            revert WrongAmount(_topUpOwnerFraction + _topUpStakerFraction, 100);
+        if (_maxBondFraction + _topUpOwnerFraction > 100) {
+            revert WrongAmount(_maxBondFraction + _topUpOwnerFraction, 100);
         }
 
         stakerFraction = _stakerFraction;
         componentFraction = _componentFraction;
         agentFraction = _agentFraction;
 
-        topUpOwnerFraction = _topUpOwnerFraction;
-        topUpStakerFraction = _topUpStakerFraction;
+        // Check if the maxBondFraction changes
+        uint256 oldMaxBondFraction = maxBondFraction;
+        if (oldMaxBondFraction != _maxBondFraction) {
+            // Epoch with the year change is ongoing, and maxBond cannot be changed
+            if (lockMaxBond == 2) {
+                revert MaxBondUpdateLocked();
+            }
 
-        emit RewardFractionsUpdated(_stakerFraction, _componentFraction, _agentFraction, _topUpOwnerFraction, _topUpStakerFraction);
+            // Calculate next maxBond based on the proposed maxBondFraction
+            uint256 nextMaxBond = inflationPerSecond * _maxBondFraction * epochLen;
+            // Adjust maxBond and effectiveBond, if they are within the allowed limits
+            _adjustMaxBond(nextMaxBond);
+
+            // Update the maxBondFraction
+            maxBondFraction = _maxBondFraction;
+        }
+        topUpOwnerFraction = _topUpOwnerFraction;
+
+        emit IncentiveFractionsUpdated(_stakerFraction, _componentFraction, _agentFraction, _maxBondFraction, _topUpOwnerFraction);
     }
 
     /// @dev Changes registries contract addresses.
@@ -340,83 +409,34 @@ contract Tokenomics is TokenomicsConstants, GenericTokenomics {
         }
     }
 
-    // TODO This has to be adjusted according to the forecast of the inflation schedule and
-    /// @dev Checks for the OLAS minting ability WRT the inflation schedule.
-    /// @param amount Amount of requested OLAS tokens to mint.
-    /// @return allowed True if the mint is allowed.
-    function isAllowedMint(uint256 amount) external view returns (bool allowed) {
-        uint256 remainder = _getInflationRemainderForYear();
-        // For the first 10 years we check the inflation cap that is pre-defined
-        if (amount < (remainder + 1)) {
-            allowed = true;
-        }
-    }
-
-    // TODO This function will be deleted or merged with the one above, since we use inflation caps for other calculations
-    /// @dev Gets remainder of possible OLAS allocation for the current year.
-    /// @return remainder OLAS amount possible to mint.
-    function _getInflationRemainderForYear() internal view returns (uint256 remainder) {
-        // Current year
-        uint256 numYears = (block.timestamp - timeLaunch) / oneYear;
-        // For the first 10 years we check the inflation cap that is pre-defined
-        if (numYears < 10) {
-            // OLAS token supply to-date
-            uint256 supply = IToken(olas).totalSupply();
-            remainder = getSupplyCapForYear(numYears) - supply;
-        } else {
-            remainder = IOLAS(olas).inflationRemainder();
-        }
-    }
-
-    /// @dev Adjusts max bond according to a new value
-    /// @notice This value is adjusted every epoch if max bond is auto-controlled.
-    function _adjustMaxBond(uint96 _maxBond) internal {
-        // Take into account the change during the epoch
-        uint96 delta;
-        if (_maxBond > maxBond) {
-            // If the new maxBond is greater than the previous one, add the difference to effectiveBond
-            delta = _maxBond - maxBond;
-            effectiveBond += delta;
-        } else {
-            // If the new maxBond is less than the previous one, subtract the difference from the effectiveBond
-            delta = maxBond - _maxBond;
-            if (delta < effectiveBond) {
-                effectiveBond -= delta;
-            } else {
-                effectiveBond = 0;
-            }
-        }
-        maxBond = _maxBond;
-    }
-
-    /// @dev Checks if the the effective bond value per current epoch is enough to allocate the specific amount.
-    /// @notice Programs exceeding the limit in the epoch are not allowed.
+    /// @dev Reserves OLAS amount from the effective bond to be minted during a bond program.
+    /// @notice Programs exceeding the limit of the effective bond are not allowed.
     /// @param amount Requested amount for the bond program.
     /// @return success True if effective bond threshold is not reached.
-    function allowedNewBond(uint96 amount) external returns (bool success)  {
+    function reserveAmountForBondProgram(uint96 amount) external returns (bool success) {
         // Check for the depository access
         if (depository != msg.sender) {
             revert ManagerOnly(msg.sender, depository);
         }
 
-        // TODO The remainder is not needed anymore since the bond fraction insures there's enough tokens to mint up to effectiveBond value
-        // Check the effective bond and remainder for the year
-        uint256 remainder = _getInflationRemainderForYear();
-        if (effectiveBond >= amount && amount < (remainder + 1)) {
+        // Effective bond must be bigger than the requested amount
+        if ((effectiveBond + 1) > amount) {
+            // The value of effective bond is then adjusted to the amount that is now reserved for bonding
+            // The unrealized part of the bonding amount will be returned when the bonding program is closed
             effectiveBond -= amount;
             success = true;
         }
     }
 
-    /// @dev Increases the epoch bond with the OLAS payout for a Depository program
-    /// @param payout Payout amount for the LP pair.
-    function updateEpochBond(uint96 payout) external {
+    /// @dev Refunds unused bond program amount when the program is closed.
+    /// @param amount Amount to be refunded from the closed bond program.
+    function refundFromBondProgram(uint96 amount) external {
         // Check for the depository access
         if (depository != msg.sender) {
             revert ManagerOnly(msg.sender, depository);
         }
 
-        bondPerEpoch += payout;
+        effectiveBond += amount;
     }
 
     /// @dev Tracks the deposited ETH amounts from services during the current epoch.
@@ -556,9 +576,10 @@ contract Tokenomics is TokenomicsConstants, GenericTokenomics {
     /// @return True if the function execution is successful.
     function checkpoint() external returns (bool) {
         // New point can be calculated only if we passed the number of blocks equal to the epoch length
-        uint256 prevEpochTime = mapEpochEconomics[epochCounter - 1].epochTime;
+        uint256 prevEpochTime = mapEpochEconomics[epochCounter - 1].endTime;
         uint256 diffNumSeconds = block.timestamp - prevEpochTime;
-        if (diffNumSeconds < epochLen) {
+        uint256 curEpochLen = epochLen;
+        if (diffNumSeconds < curEpochLen) {
             return false;
         }
 
@@ -569,56 +590,90 @@ contract Tokenomics is TokenomicsConstants, GenericTokenomics {
         rewards[2] = (rewards[0] * stakerFraction) / 100;
         rewards[3] = (rewards[0] * componentFraction) / 100;
         rewards[4] = (rewards[0] * agentFraction) / 100;
+        // Treasury reward calculation
         rewards[1] = rewards[0] - rewards[2] - rewards[3] - rewards[4];
 
-        // Top-ups and bonding possibility in OLAS are recalculated based on the inflation schedule per epoch
-        // TODO Study if diffNumSeconds must be instead of epochLen here, since we could start new epoch later than epochLen
-        // TODO This calculation is wrong - we should allocate more or less equal amount per each epoch, however from this
-        // TODO formula we will get fewer and fewer top-ups until the end of the year
-        // OLAS inflation is split between:
-        // 5: ownerTopUps, 6: stakerTopUps, 7: possibleBondAllocation
+        // The actual inflation per epoch considering that it is settled not in the exact epochLen time, but a bit later
         uint256 inflationPerEpoch;
+        // Get the maxBond that was credited to effectiveBond during this settled epoch
+        // If the year changes, the maxBond for the next epoch is updated in the condition below and will be used
+        // later when the effectiveBond is updated for the next epoch
+        uint256 curMaxBond = maxBond;
         // Current year
         uint256 numYears = (block.timestamp - timeLaunch) / oneYear;
-        // Account for the year change to adjust inflation numbers
+        // There amounts for the yearly inflation change from year to year, so if the year changes in the middle
+        // of the epoch, it is necessary to adjust the epoch inflation numbers to account for the year change
         if (numYears > currentYear) {
             // Calculate remainder of inflation for the passing year
             uint256 curInflationPerSecond = inflationPerSecond;
-            // End of the year minus previous epoch timestamp
+            // End of the year timestamp
             uint256 yearEndTime = timeLaunch + numYears * oneYear;
+            // Initial inflation per epoch during the end of the year minus previous epoch timestamp
             inflationPerEpoch = (yearEndTime - prevEpochTime) * curInflationPerSecond;
-            // Recalculate inflation per second based on a new year inflation
+            // Recalculate the inflation per second based on the new inflation for the current year
             curInflationPerSecond = getInflationForYear(numYears) / oneYear;
             // Add the remainder of inflation amount for this epoch based on a new inflation per second ratio
             inflationPerEpoch += (block.timestamp - yearEndTime) * curInflationPerSecond;
-            // TODO Check if anythings re bonding needs to be updated
+            // Update the maxBond value for the next epoch after the year changes
+            maxBond = uint96(curInflationPerSecond * curEpochLen * maxBondFraction) / 100;
             // Updating state variables
             inflationPerSecond = uint96(curInflationPerSecond);
             currentYear = uint8(numYears);
+            // maxBond lock is released and can be changed starting from the new epoch
+            lockMaxBond = 1;
         } else {
             inflationPerEpoch = inflationPerSecond * diffNumSeconds;
         }
-        // TODO must be based on bondPerEpoch or based on inflation, if the flag is set
-        // TODO Check the connection to the maxBond such that we don't overflow the specified maxBond amount
-        // TODO Make sure we don't go beyond the inflation schedule limit
-        rewards[5] = (inflationPerEpoch * topUpOwnerFraction) / 100;
-        rewards[6] = (inflationPerEpoch * topUpStakerFraction) / 100;
-        // All the leftovers from the inflation schedule allocation is given in favor of bonding programs
-        // If that value is bigger than the current maxBond, it will be adjusted (in case of contract-controlled maxBond)
+
+        // Bonding and top-ups in OLAS are recalculated based on the inflation schedule per epoch
+        // OLAS inflation is split between:
+        // 5: maxBond, 6: ownerTopUps, 7: stakerTopUps
+        // Actual maxBond of the epoch
+        rewards[5] = (inflationPerEpoch * maxBondFraction) / 100;
+        // Owner top-ups: epoch incentives for component / agent owners funded with the inflation
+        rewards[6] = (inflationPerEpoch * topUpOwnerFraction) / 100;
+        // Staker top-ups: epoch incentives for veOLAS lockers funded with the inflation
         rewards[7] = inflationPerEpoch - rewards[5] - rewards[6];
 
-        // Effective bond accumulates leftovers from previous epochs (with the last max bond value set)
-        // TODO maxBond must be also recalculated based on when new epoch has started, as per additional (diffNumSeconds - epochLen)
-        if (bondPerEpoch < maxBond) {
-            effectiveBond += maxBond - bondPerEpoch;
+        // Effective bond accumulates bonding leftovers from previous epochs (with the last max bond value set)
+        // It is given the value of the maxBond for the next epoch as a credit
+        // The difference between recalculated max bond per epoch and maxBond value must be reflected in effectiveBond,
+        // since the epoch checkpoint delay was not accounted for initially
+        // TODO optimize for gas usage below
+        // TODO Prove that the adjusted maxBond (rewards[5]) will never be lower than the epoch maxBond
+        // This has to always be true, or rewards[5] == curMaxBond if the epoch is settled exactly at the epochLen time
+        if (rewards[5] > curMaxBond) {
+            // Adjust the effectiveBond
+            rewards[5] = effectiveBond + rewards[5] - curMaxBond;
+            effectiveBond = uint96(rewards[5]);
         }
-        // Bond per epoch starts from zero every epoch
-        bondPerEpoch = 0;
-        // Adjust max bond and effective bond if the contract-controlled max bond is enabled
-        // Note that effectiveBond is also adjusted, if needed, however the bondPerEpoch is already accounted for earlier
-        if (bondAutoControl) {
-            _adjustMaxBond(uint96(rewards[7]));
+
+        // Adjust max bond value if the next epoch is going to be the year change epoch
+        // Note that this computation happens before the epoch that is triggered in the next epoch (the code above) when
+        // the actual year will change
+        numYears = (block.timestamp + curEpochLen - timeLaunch) / oneYear;
+        // Account for the year change to adjust the max bond
+        if (numYears > currentYear) {
+            // Calculate remainder of inflation for the passing year
+            uint256 curInflationPerSecond = inflationPerSecond;
+            // End of the year timestamp
+            uint256 yearEndTime = timeLaunch + numYears * oneYear;
+            // Calculate the  max bond value until the end of the year
+            curMaxBond = (yearEndTime - block.timestamp) * curInflationPerSecond * maxBondFraction / 100;
+            // Recalculate the inflation per second based on the new inflation for the current year
+            curInflationPerSecond = getInflationForYear(numYears) / oneYear;
+            // Add the remainder of max bond amount for the next epoch based on a new inflation per second ratio
+            curMaxBond += (block.timestamp + curEpochLen - yearEndTime) * curInflationPerSecond * maxBondFraction / 100;
+            maxBond = uint96(curMaxBond);
+            // maxBond lock is set and cannot be changed until the next epoch with the year change passes
+            lockMaxBond = 2;
+        } else {
+            // This assignment is done again to account for the maxBond value that could change if we are currently
+            // in the epoch with a changing year
+            curMaxBond = maxBond;
         }
+        // Update effectiveBond with the current or updated maxBond value
+        effectiveBond += uint96(curMaxBond);
 
         // idf = 1 / (1 + iterest_rate), reverse_df = 1/df >= 1.0.
         uint64 idf;
@@ -628,12 +683,12 @@ contract Tokenomics is TokenomicsConstants, GenericTokenomics {
         uint256 numServices = protocolServiceIds.length;
         if (rewards[0] > 0) {
             // Calculate total UCFc
-            ucfc = _calculateUnitTokenomics(IServiceTokenomics.UnitType.Component, rewards[3], rewards[5], numServices);
+            ucfc = _calculateUnitTokenomics(IServiceTokenomics.UnitType.Component, rewards[3], rewards[6], numServices);
             ucfc.ucfWeight = uint8(ucfcWeight);
             ucfc.unitWeight = uint8(componentWeight);
 
             // Calculate total UCFa
-            ucfa = _calculateUnitTokenomics(IServiceTokenomics.UnitType.Agent, rewards[4], rewards[5], numServices);
+            ucfa = _calculateUnitTokenomics(IServiceTokenomics.UnitType.Agent, rewards[4], rewards[6], numServices);
             ucfa.ucfWeight = uint8(ucfaWeight);
             ucfa.unitWeight = uint8(agentWeight);
 
@@ -668,7 +723,7 @@ contract Tokenomics is TokenomicsConstants, GenericTokenomics {
 
         // Record settled epoch point
         PointEcomonics memory newPoint = PointEcomonics(ucfc, ucfa, idf, uint32(numServices), uint96(rewards[1]),
-            uint96(rewards[2]), epochServiceDonationETH, uint96(rewards[5]), uint96(rewards[6]), devsPerCapital,
+            uint96(rewards[2]), epochServiceDonationETH, uint96(rewards[6]), uint96(rewards[7]), devsPerCapital,
             uint32(block.number), uint32(block.timestamp));
         uint32 eCounter = epochCounter;
         mapEpochEconomics[eCounter] = newPoint;
@@ -679,7 +734,7 @@ contract Tokenomics is TokenomicsConstants, GenericTokenomics {
 
         // Allocate rewards via Treasury and start new epoch
         uint96 accountRewards = uint96(rewards[2]) + ucfc.unitRewards + ucfa.unitRewards;
-        uint96 accountTopUps = uint96(rewards[5] + rewards[6]);
+        uint96 accountTopUps = uint96(rewards[6] + rewards[7]);
 
         // Treasury contract allocates rewards
         if (ITreasury(treasury).allocateRewards(uint96(rewards[1]), accountRewards, accountTopUps)) {
@@ -715,7 +770,7 @@ contract Tokenomics is TokenomicsConstants, GenericTokenomics {
             uint96 stakerRewards = mapEpochEconomics[endEpochNumber].stakerRewards;
             uint96 stakerTopUps = mapEpochEconomics[endEpochNumber].stakerTopUps;
             // Last block number of a previous epoch
-            uint256 iBlock = mapEpochEconomics[endEpochNumber - 1].blockNumber - 1;
+            uint256 iBlock = mapEpochEconomics[endEpochNumber - 1].endBlockNumber - 1;
             // Get account's balance at the end of epoch
             uint256 balance = IVotingEscrow(ve).balanceOfAt(account, iBlock);
 

--- a/contracts/TokenomicsConstants.sol
+++ b/contracts/TokenomicsConstants.sol
@@ -7,7 +7,7 @@ pragma solidity ^0.8.17;
 abstract contract TokenomicsConstants {
     // Timestamp of the OLAS token deployment
     uint256 public constant timeLaunch = 1656584807;
-    // One year interval
+    // One year in seconds
     uint256 public constant oneYear = 1 days * 365;
     // Number of seconds left in a year of deployment
     // This value is necessary since it is different from a precise one year time, as the OLAS contract started earlier
@@ -61,6 +61,7 @@ abstract contract TokenomicsConstants {
         // For the first 10 years the inflation caps are pre-defined as differences between next year cap and current year one
         if (numYears < 10) {
             // Initial OLAS allocation is 526_500_000_0e17
+            // TODO study if it's cheaper to allocate new uint256[](10)
             uint88[10] memory inflationAmounts = [
                 22_113_000_0e17,
                 79_548_885_0e17,
@@ -83,7 +84,7 @@ abstract contract TokenomicsConstants {
             uint256 maxMintCapFraction = 2;
 
             // Get the supply cap until the year before the current year
-            for (uint256 i = 0; i < numYears - 1; ++i) {
+            for (uint256 i = 1; i < numYears; ++i) {
                 supplyCap += (supplyCap * maxMintCapFraction) / 100;
             }
 

--- a/contracts/interfaces/IErrorsTokenomics.sol
+++ b/contracts/interfaces/IErrorsTokenomics.sol
@@ -65,10 +65,6 @@ interface IErrorsTokenomics {
     /// @param actual Actual supply left.
     error ProductSupplyLow(address tokenAddress, uint256 productId, uint256 requested, uint256 actual);
 
-    /// @dev Minting is rejected due to the requested amount bigger than the current inflation policy cap.
-    /// @param amount Amount of tokens to mint.
-    error MintRejectedByInflationPolicy(uint256 amount);
-
     /// @dev Incorrect amount received / provided.
     /// @param provided Provided amount is lower.
     /// @param expected Expected amount.
@@ -97,4 +93,12 @@ interface IErrorsTokenomics {
     /// @dev Failure of reward allocation.
     /// @param epochNumber Epoch number.
     error RewardsAllocationFailed(uint256 epochNumber);
+
+    /// @dev maxBond parameter is locked and cannot be updated.
+    error MaxBondUpdateLocked();
+
+    /// @dev Rejects the max bond adjustment.
+    /// @param maxBondAmount Max bond amount available at the moment.
+    /// @param delta Delta bond amount to be subtracted from the maxBondAmount.
+    error RejectMaxBondAdjustment(uint256 maxBondAmount, uint256 delta);
 }

--- a/contracts/interfaces/ITokenomics.sol
+++ b/contracts/interfaces/ITokenomics.sol
@@ -17,15 +17,15 @@ interface ITokenomics {
     function trackServicesETHRevenue(uint32[] memory serviceIds, uint96[] memory amounts) external
         returns (uint96 donationETH);
 
-    /// @dev Increases the epoch bond with the OLAS payout for a Depository program
-    /// @param payout Payout amount for the LP pair.
-    function updateEpochBond(uint96 payout) external;
-
-    /// @dev Checks if the the effective bond value per current epoch is enough to allocate the specific amount.
+    /// @dev Reserves OLAS amount from the effective bond to be minted during a bond program.
     /// @notice Programs exceeding the limit in the epoch are not allowed.
     /// @param amount Requested amount for the bond program.
     /// @return True if effective bond threshold is not reached.
-    function allowedNewBond(uint96 amount) external returns(bool);
+    function reserveAmountForBondProgram(uint96 amount) external returns(bool);
+
+    /// @dev Refunds unused bond program amount.
+    /// @param amount Amount to be refunded from the bond program.
+    function refundFromBondProgram(uint96 amount) external;
 
     /// @dev Gets the component / agent owner reward and zeros the record of it being written off.
     /// @param account Account address.
@@ -41,11 +41,6 @@ interface ITokenomics {
     /// @return endEpochNumber Epoch number where the reward calculation will start the next time.
     function calculateStakingRewards(address account, uint256 startEpochNumber) external view
         returns (uint256 reward, uint256 topUp, uint256 endEpochNumber);
-
-    /// @dev Checks for the OLA minting ability WRT the inflation schedule.
-    /// @param amount Amount of requested OLA tokens to mint.
-    /// @return True if the mint is allowed.
-    function isAllowedMint(uint256 amount) external returns (bool);
 
     /// @dev Gets inverse discount factor with the multiple of 1e18 of the last epoch.
     /// @return idf Discount factor with the multiple of 1e18.

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -36,15 +36,6 @@ module.exports = {
                 },
             },
             {
-                version: "0.7.5",  // FixedPoint math from OlympusDAO, not compatible with 8.x
-                settings: {
-                    optimizer: {
-                        enabled: true,
-                        runs: 1000,
-                    },
-                },
-            },
-            {
                 version: "0.5.16", // uniswap
             },
             {

--- a/test/Depository.js
+++ b/test/Depository.js
@@ -30,8 +30,8 @@ describe("Depository LP", async () => {
     let tokenomics;
     let epochLen = 100;
 
-    // 2,000
-    let supplyProductOLAS =  "2" + "0".repeat(3) + decimals;
+    // 2,200
+    let supplyProductOLAS =  "22" + "0".repeat(2) + decimals;
     let pseudoFlashLoan = "2"  + "0".repeat(2) + decimals;
     const maxUint96 = "79228162514264337593543950335";
     const maxUint32 = "4294967295";
@@ -70,7 +70,7 @@ describe("Depository LP", async () => {
         // Correct depository address is missing here, it will be defined just one line below
         treasury = await treasuryFactory.deploy(olas.address, deployer.address, tokenomics.address, AddressZero);
         // Change bond fraction to 100% in these tests
-        await tokenomics.changeRewardFraction(50, 33, 17, 0, 0);
+        await tokenomics.changeIncentiveFractions(50, 33, 17, 100, 0);
 
         // Deploy generic bond calculator contract
         const GenericBondCalculator = await ethers.getContractFactory("GenericBondCalculator");
@@ -431,6 +431,16 @@ describe("Depository LP", async () => {
             await depository.close(pairODAI.address, bid);
             product = await depository.getProduct(pairODAI.address, bid);
             expect(Number(product.supply)).to.equal(0);
+        });
+
+        it("Create a bond product, deposit, then close it", async () => {
+            // Transfer more LP tokens to Bob
+            const amountTo = new ethers.BigNumber.from(await pairODAI.balanceOf(deployer.address)).div(4);
+            await pairODAI.connect(deployer).transfer(bob.address, amountTo);
+            // Deposit for the full amount of OLAS
+            const bamount = "2" + "0".repeat(3) + decimals;
+            await depository.connect(bob).deposit(pairODAI.address, bid, bamount, bob.address);
+            await depository.close(pairODAI.address, bid);
         });
     });
 

--- a/test/Tokenomics.js
+++ b/test/Tokenomics.js
@@ -1,11 +1,13 @@
 /*global describe, beforeEach, it, context*/
-const { ethers, network } = require("hardhat");
+const { ethers } = require("hardhat");
 const { expect } = require("chai");
+const helpers = require("@nomicfoundation/hardhat-network-helpers");
 
 describe("Tokenomics", async () => {
     const initialMint = "1" + "0".repeat(26);
     const AddressZero = "0x" + "0".repeat(40);
     const maxUint96 = "79228162514264337593543950335";
+    const oneYear = 86400 * 365;
 
     let signers;
     let deployer;
@@ -94,36 +96,62 @@ describe("Tokenomics", async () => {
             ).to.be.revertedWithCustomError(tokenomics, "OwnerOnly");
         });
 
+        it("Get inflation numbers", async function () {
+            const fiveYearSupplyCap = await tokenomics.getSupplyCapForYear(5);
+            expect(fiveYearSupplyCap).to.equal("8718353429" + "0".repeat(17));
+
+            const elevenYearSupplyCap = await tokenomics.getSupplyCapForYear(11);
+            expect(elevenYearSupplyCap).to.equal("10404" + "0".repeat(23));
+
+            const fiveYearInflationAmount = await tokenomics.getInflationForYear(5);
+            expect(fiveYearInflationAmount).to.equal("488771339" + "0".repeat(17));
+
+            const elevenYearInflationAmount = await tokenomics.getInflationForYear(11);
+            expect(elevenYearInflationAmount).to.equal("204" + "0".repeat(23));
+        });
+
         it("Changing tokenomics parameters", async function () {
             // Trying to change tokenomics parameters from a non-owner account address
             await expect(
-                tokenomics.connect(signers[1]).changeTokenomicsParameters(10, 10, 10, 10, 10, 10, 10, 10, 10, true)
+                tokenomics.connect(signers[1]).changeTokenomicsParameters(10, 10, 10, 10, 10, 10, 10)
             ).to.be.revertedWithCustomError(tokenomics, "OwnerOnly");
 
-            await tokenomics.changeTokenomicsParameters(10, 10, 10, 10, 10, 10, 10, 10, 10, true);
+            await tokenomics.changeTokenomicsParameters(10, 10, 10, 10, 10, 10, 10);
+            // Change epoch len to a smaller value
+            await tokenomics.changeTokenomicsParameters(10, 10, 10, 10, 10, 10, 1);
+            // Leave the epoch length untouched
+            await tokenomics.changeTokenomicsParameters(10, 10, 10, 10, 10, 10, 1);
+            // And then change back to the bigger one
+            await tokenomics.changeTokenomicsParameters(10, 10, 10, 10, 10, 10, 8);
+            // Try to set the epochLen to zero that must fail due to effectiveBond going to zero
+            await expect(
+                tokenomics.changeTokenomicsParameters(10, 10, 10, 10, 10, 10, 0)
+            ).to.be.revertedWithCustomError(tokenomics, "RejectMaxBondAdjustment");
 
             // Trying to set epsilonRate bigger than 17e18
-            await tokenomics.changeTokenomicsParameters(10, 10, 10, 10, 10, "171"+"0".repeat(17), 10, 10, 10, true);
+            await tokenomics.changeTokenomicsParameters(10, 10, 10, 10, 10, "171"+"0".repeat(17), 10);
             expect(await tokenomics.epsilonRate()).to.equal(10);
         });
 
         it("Changing reward fractions", async function () {
             // Trying to change tokenomics reward fractions from a non-owner account address
             await expect(
-                tokenomics.connect(signers[1]).changeRewardFraction(50, 50, 50, 0, 0)
+                tokenomics.connect(signers[1]).changeIncentiveFractions(50, 50, 50, 100, 0)
             ).to.be.revertedWithCustomError(tokenomics, "OwnerOnly");
 
             // The sum of first 3 must not be bigger than 100
             await expect(
-                tokenomics.connect(deployer).changeRewardFraction(50, 50, 50, 0, 0)
+                tokenomics.connect(deployer).changeIncentiveFractions(50, 50, 50, 100, 0)
             ).to.be.revertedWithCustomError(tokenomics, "WrongAmount");
 
             // The sum of last 2 must not be bigger than 100
             await expect(
-                tokenomics.connect(deployer).changeRewardFraction(50, 40, 10, 50, 51)
+                tokenomics.connect(deployer).changeIncentiveFractions(50, 40, 10, 50, 51)
             ).to.be.revertedWithCustomError(tokenomics, "WrongAmount");
 
-            await tokenomics.connect(deployer).changeRewardFraction(30, 40, 10, 40, 50);
+            await tokenomics.connect(deployer).changeIncentiveFractions(30, 40, 10, 10, 50);
+            // Try to set exactly same values again
+            await tokenomics.connect(deployer).changeIncentiveFractions(30, 40, 10, 10, 50);
         });
 
         it("Changing registries addresses", async function () {
@@ -143,11 +171,11 @@ describe("Tokenomics", async () => {
 
         it("Should fail when calling depository-owned functions by other addresses", async function () {
             await expect(
-                tokenomics.connect(signers[1]).allowedNewBond(0)
+                tokenomics.connect(signers[1]).reserveAmountForBondProgram(0)
             ).to.be.revertedWithCustomError(tokenomics, "ManagerOnly");
 
             await expect(
-                tokenomics.connect(signers[1]).updateEpochBond(0)
+                tokenomics.connect(signers[1]).refundFromBondProgram(0)
             ).to.be.revertedWithCustomError(tokenomics, "ManagerOnly");
         });
 
@@ -161,32 +189,6 @@ describe("Tokenomics", async () => {
             await expect(
                 tokenomics.connect(signers[1]).accountOwnerRewards(deployer.address)
             ).to.be.revertedWithCustomError(tokenomics, "ManagerOnly");
-        });
-    });
-
-    context("Inflation schedule", async function () {
-        it("Check if the mint is allowed", async () => {
-            // Trying to mint more than the inflation remainder for the year
-            let allowed = await tokenomics.connect(deployer).callStatic.isAllowedMint(initialMint.repeat(2));
-            expect(allowed).to.equal(false);
-
-            allowed = await tokenomics.connect(deployer).callStatic.isAllowedMint(1000);
-            expect(allowed).to.equal(true);
-        });
-
-        it("Check if the new bond is allowed", async () => {
-            // Trying to get a new bond amount more than the inflation remainder for the year
-            let allowed = await tokenomics.connect(deployer).callStatic.allowedNewBond(maxUint96);
-            expect(allowed).to.equal(false);
-
-            allowed = await tokenomics.connect(deployer).callStatic.allowedNewBond(1000);
-            expect(allowed).to.equal(true);
-
-            // Check the same condition after 10 years
-            await network.provider.send("evm_increaseTime", [3153600000]);
-            await ethers.provider.send("evm_mine");
-            allowed = await tokenomics.connect(deployer).callStatic.allowedNewBond(1000);
-            expect(allowed).to.equal(true);
         });
     });
 
@@ -215,13 +217,8 @@ describe("Tokenomics", async () => {
             await ethers.provider.send("evm_mine");
             await tokenomics.connect(deployer).checkpoint();
 
-            // Set the auto-control of effective bond calculation
-            await tokenomics.changeTokenomicsParameters(10, 10, 10, 10, 10, 10, 10, 1, 10, true);
-            await ethers.provider.send("evm_mine");
-            await tokenomics.connect(deployer).checkpoint();
-
             // Try to run checkpoint while the epoch length is not yet reached
-            await tokenomics.changeTokenomicsParameters(10, 10, 10, 10, 10, 10, 10, 10, 10, true);
+            await tokenomics.changeTokenomicsParameters(10, 10, 10, 10, 10, 10, 10);
             await tokenomics.connect(deployer).checkpoint();
         });
 
@@ -271,17 +268,14 @@ describe("Tokenomics", async () => {
             await treasury.connect(deployer).depositETHFromServices(accounts, [regDepositFromServices,
                 regDepositFromServices], {value: twoRegDepositFromServices});
             // Start new epoch and calculate tokenomics parameters and rewards
-            await tokenomics.changeTokenomicsParameters(10, 10, 10, 10, 10, 10, 0, 10, 10, true);
+            await tokenomics.changeTokenomicsParameters(10, 10, 10, 10, 10, 10, 10);
+            await helpers.time.increase(10);
             await tokenomics.connect(deployer).checkpoint();
 
             // Get IDF
             const lastEpoch = await tokenomics.epochCounter() - 1;
             const idf = Number(await tokenomics.getIDF(lastEpoch)) / E18;
             expect(idf).to.greaterThan(Number(await tokenomics.epsilonRate()) / E18);
-
-            // Change max bond twice such that adjustment of max bond is tested
-            await tokenomics.changeTokenomicsParameters(10, 10, 10, 10, 10, 10, 1, 10, 10, true);
-            await tokenomics.changeTokenomicsParameters(10, 10, 10, 10, 10, 10, 0, 10, 10, true);
         });
     });
 
@@ -319,6 +313,77 @@ describe("Tokenomics", async () => {
             // Get the top-up number per epoch
             const topUp = await tokenomics.getTopUpPerEpoch();
             expect(topUp).to.greaterThan(0);
+        });
+    });
+
+    context("Time sensitive tests", async function () {
+        it("Check if the OLAS amount bond is available for the bond program", async () => {
+            // Take a snapshot of the current state of the blockchain
+            const snapshot = await helpers.takeSnapshot();
+
+            // Trying to get a new bond amount more than the inflation remainder for the year
+            let allowed = await tokenomics.connect(deployer).callStatic.reserveAmountForBondProgram(maxUint96);
+            expect(allowed).to.equal(false);
+
+            allowed = await tokenomics.connect(deployer).callStatic.reserveAmountForBondProgram(1000);
+            expect(allowed).to.equal(true);
+
+            // Check the same condition after 10 years
+            await helpers.time.increase(3153600000);
+            allowed = await tokenomics.connect(deployer).callStatic.reserveAmountForBondProgram(1000);
+            expect(allowed).to.equal(true);
+
+            // Restore to the state of the snapshot
+            await snapshot.restore();
+        });
+
+        it("Get to the epoch before the end of the OLAS year and try to change maxBond or epochLen", async () => {
+            // Take a snapshot of the current state of the blockchain
+            const snapshot = await helpers.takeSnapshot();
+
+            // Set epochLen to 10 seconds
+            const currentEpochLen = 10;
+            await tokenomics.changeTokenomicsParameters(1, 1, 1, 1, 1, 1, currentEpochLen);
+
+            // OLAS starting time
+            const timeLaunch = Number(await tokenomics.timeLaunch());
+            // One year time from the launch
+            const yearChangeTime = timeLaunch + Number(oneYear);
+
+            // Get to the time of more than one epoch length before the year change (1.5 epoch length)
+            let timeEpochBeforeYearChange = yearChangeTime - currentEpochLen - 5;
+            await helpers.time.increaseTo(timeEpochBeforeYearChange);
+            await tokenomics.checkpoint();
+            // Try to change the epoch length now such that the next epoch will immediately have the year change
+            await expect(
+                tokenomics.changeTokenomicsParameters(1, 1, 1, 1, 1, 1, 20)
+            ).to.be.revertedWithCustomError(tokenomics, "MaxBondUpdateLocked");
+
+            // Get to the time of the half epoch length before the year change
+            // Meaning that the year does not change yet during the current epoch, but it will during the next one
+            timeEpochBeforeYearChange += currentEpochLen;
+            await helpers.time.increaseTo(timeEpochBeforeYearChange);
+            await tokenomics.checkpoint();
+
+            // The maxBond lock flag must be set to true, now try to change the epochLen
+            await expect(
+                tokenomics.changeTokenomicsParameters(1, 1, 1, 1, 1, 1, 1)
+            ).to.be.revertedWithCustomError(tokenomics, "MaxBondUpdateLocked");
+            // Try to change the maxBondFraction as well
+            await expect(
+                tokenomics.changeIncentiveFractions(30, 40, 10, 50, 50)
+            ).to.be.revertedWithCustomError(tokenomics, "MaxBondUpdateLocked");
+
+            // Now skip one epoch
+            await helpers.time.increaseTo(timeEpochBeforeYearChange + currentEpochLen);
+            await tokenomics.checkpoint();
+
+            // Change parameters now
+            await tokenomics.changeTokenomicsParameters(1, 1, 1, 1, 1, 1, 1);
+            await tokenomics.changeIncentiveFractions(30, 40, 10, 50, 50);
+
+            // Restore to the state of the snapshot
+            await snapshot.restore();
         });
     });
 });


### PR DESCRIPTION
- Recalculating top-ups based on the inflation schedule and top-ups per second ratio according to the approved specification;
- Accounting for the year change scenario and the top-ups ratio change in the middle of the epoch;
- Tests are not yet updated.