### PR TITLE
refactor: use real incentive numbers instead of fractions

### DIFF
--- a/test/Tokenomics.js
+++ b/test/Tokenomics.js
@@ -331,19 +331,19 @@ describe("Tokenomics", async () => {
             const up = [await tokenomics.getUnitPoint(lastPoint, 0), await tokenomics.getUnitPoint(lastPoint, 1)];
             // Calculate rewards based on the points information
             const rewards = [
-                (Number(ep.totalDonationsETH) * Number(ep.rewardStakerFraction)) / 100,
-                (Number(ep.totalDonationsETH) * Number(up[0].rewardUnitFraction)) / 100,
-                (Number(ep.totalDonationsETH) * Number(up[1].rewardUnitFraction)) / 100
+                Number(ep.stakerRewards),
+                Number(up[0].unitRewards),
+                Number(up[1].unitRewards)
             ];
             const accountRewards = rewards[0] + rewards[1] + rewards[2];
             // Calculate top-ups based on the points information
             let topUps = [
-                (Number(ep.totalTopUpsOLAS) * Number(ep.maxBondFraction)) / 100,
-                (Number(ep.totalTopUpsOLAS) * Number(up[0].topUpUnitFraction)) / 100,
-                (Number(ep.totalTopUpsOLAS) * Number(up[1].topUpUnitFraction)) / 100,
-                Number(ep.totalTopUpsOLAS)
+                Number(ep.totalTopUpsOLAS),
+                Number(up[0].unitTopUps),
+                Number(up[1].unitTopUps),
+                Number(ep.stakerTopUps)
             ];
-            topUps[3] -= topUps[0] + topUps[1] + topUps[2];
+            topUps[0] -= topUps[1] + topUps[2] + topUps[3];
             const accountTopUps = topUps[1] + topUps[2] + topUps[3];
             expect(accountRewards).to.greaterThan(0);
             expect(accountTopUps).to.greaterThan(0);


### PR DESCRIPTION
### This PR is temporary and will be closed, it didn't prove gas savings when we have real incentive numbers instead of fractions.

- `checkpoint()` is 60k gas more expensive due to the usage of `uint96` variables compared to `uint8`;
- Staker incentives in the loop of 20 epochs is just 38k gas cheaper;
- Owner incentives is 300 gas more expensive;
- Depositing is 100 gas more expensive.
- Overall, this approach is more expensive for the protocol, for the donators and unit owner claimers, and does not gain much for stakers (which will be not activated anyway at the beginning).

Here are the numbers for the integration tests:
Using fractions (in max values):
Dispenser.claimOwnerIncentives(): 131388;
Dispenser.claimStakingIncentives(): 1255287; 
Tokenomics.checkpoint(): 160588; 
Treasury.depositETHFromServices(): 1316716.

Using real incentives in points and not their fractions (in max values):
Dispenser.claimOwnerIncentives(): 131620;
Dispenser.laimStakingIncentives(): 1187587;
Tokenomics.checkpoin(): 224290;
Treasury.depositETHFromServices(): 1316806.

