### PR TITLE
Fixed typo in variable name and optimized array length handling

### DIFF
--- a/contracts/Depository.sol
+++ b/contracts/Depository.sol
@@ -87,7 +87,7 @@ contract Depository is IErrorsTokenomics {
 
     // OLAS token address
     address public immutable olas;
-    // Tkenomics contract address
+    // Tokenomics contract address
     address public tokenomics;
     // Treasury contract address
     address public treasury;

--- a/contracts/DonatorBlacklist.sol
+++ b/contracts/DonatorBlacklist.sol
@@ -60,11 +60,17 @@ contract DonatorBlacklist {
         }
 
         // Check for the array length
-        if (accounts.length != statuses.length) {
-            revert WrongArrayLength(accounts.length, statuses.length);
+        uint256 accountsLength = accounts.length;
+        if (accountsLength != statuses.length) {
+            revert WrongArrayLength(accountsLength, statuses.length);
         }
 
-        for (uint256 i = 0; i < accounts.length; ++i) {
+        // Check if arrays are not empty
+        if (accountsLength == 0) {
+            revert WrongArrayLength(0, 0);
+        }
+
+        for (uint256 i = 0; i < accountsLength; ++i) {
             // Check for the zero address
             if (accounts[i] == address(0)) {
                 revert ZeroAddress();

--- a/contracts/Tokenomics.sol
+++ b/contracts/Tokenomics.sol
@@ -1388,8 +1388,14 @@ contract Tokenomics is TokenomicsConstants {
         uint256[] memory unitIds
     ) external view returns (uint256 reward, uint256 topUp) {
         // Check array lengths
-        if (unitTypes.length != unitIds.length) {
-            revert WrongArrayLength(unitTypes.length, unitIds.length);
+        uint256 unitIdsLength = unitIds.length;
+        if (unitTypes.length != unitIdsLength) {
+            revert WrongArrayLength(unitTypes.length, unitIdsLength);
+        }
+        
+        // Check if arrays are not empty
+        if (unitTypes.length == 0) {
+            revert WrongArrayLength(0, 0);
         }
 
         // Component / agent registry addresses
@@ -1404,7 +1410,7 @@ contract Tokenomics is TokenomicsConstants {
 
         // Check the input data
         uint256[] memory lastIds = new uint256[](2);
-        for (uint256 i = 0; i < unitIds.length; ++i) {
+        for (uint256 i = 0; i < unitIdsLength; ++i) {
             // Check for the unit type to be component / agent only
             if (unitTypes[i] > 1) {
                 revert Overflow(unitTypes[i], 1);
@@ -1426,7 +1432,7 @@ contract Tokenomics is TokenomicsConstants {
         // Get the current epoch counter
         uint256 curEpoch = epochCounter;
 
-        for (uint256 i = 0; i < unitIds.length; ++i) {
+        for (uint256 i = 0; i < unitIdsLength; ++i) {
             // Get the last epoch number the incentives were accumulated for
             uint256 lastEpoch = mapUnitIncentives[unitTypes[i]][unitIds[i]].lastEpoch;
             // Calculate rewards and top-ups if there were pending ones from the previous epoch


### PR DESCRIPTION
1. Fixed typo in variable 
`// Tkenomics contract address > // Tokenomics contract address`

2. Added checks for non-empty arrays in some places and stored their length in a variable.
 - contracts/DonatorBlacklist.sol > setDonatorsStatuses
 - contracts/Tokenomics.sol > getOwnerIncentives

3. In the TokenomicsConstants.sol contract, it might be worth moving `inflationAmounts` and `supplyCaps` to constant arrays.