### PR TITLE
feat and test: Bridge2Burner for Polygon and Arbitrum, added fork tes…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,8 @@ forge test -f $FORK_ETH_NODE_URL --mc BuyBackBurnerUniswapETH -vvv
 forge test -f $FORK_BASE_NODE_URL --mc LiquidityManagerBase -vvv      # Fork tests (Base)
 forge test -f $FORK_BASE_NODE_URL --mc BalancerPriceOracleBase -vvv
 forge test -f $FORK_BASE_NODE_URL --mc BuyBackBurnerBalancerBase -vvv
+forge test -f $FORK_POLYGON_NODE_URL --mc BuyBackBurnerBalancerPolygon -vvv   # Fork tests (Polygon)
+forge test -f $FORK_ARBITRUM_NODE_URL --mc BuyBackBurnerBalancerArbitrum -vvv  # Fork tests (Arbitrum)
 ```
 
 ### Coverage
@@ -93,7 +95,7 @@ L1→L2 incentive distribution uses a paired processor/dispenser pattern per cha
 ### Utilities (`contracts/utils/`)
 
 - `BuyBackBurner*` — Buy-back-and-burn mechanisms (Uniswap and Balancer variants) with proxy support
-- `Bridge2Burner*` — Bridge tokens then burn (Gnosis, Optimism variants)
+- `Bridge2Burner*` — Bridge tokens then burn (Gnosis, Optimism, Polygon, Arbitrum variants)
 
 ### Price Oracles (`contracts/oracles/`)
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ forge test -f $FORK_ETH_NODE_URL --mc BuyBackBurnerUniswapETH -vvv
 forge test -f $FORK_BASE_NODE_URL --mc LiquidityManagerBase -vvv
 forge test -f $FORK_BASE_NODE_URL --mc BalancerPriceOracleBase -vvv
 forge test -f $FORK_BASE_NODE_URL --mc BuyBackBurnerBalancerBase -vvv
+
+# Fork tests (Polygon)
+forge test -f $FORK_POLYGON_NODE_URL --mc BuyBackBurnerBalancerPolygon -vvv
+
+# Fork tests (Arbitrum)
+forge test -f $FORK_ARBITRUM_NODE_URL --mc BuyBackBurnerBalancerArbitrum -vvv
 ```
 
 ### Audits

--- a/contracts/utils/Bridge2BurnerArbitrum.sol
+++ b/contracts/utils/Bridge2BurnerArbitrum.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Bridge2Burner} from "./Bridge2Burner.sol";
+
+// ERC20 token interface
+interface IToken {
+    /// @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+    /// @param spender Account address that will be able to transfer tokens on behalf of the caller.
+    /// @param amount Token amount.
+    /// @return True if the function execution is successful.
+    function approve(address spender, uint256 amount) external returns (bool);
+}
+
+// Bridge interface
+interface IBridge {
+    // Source: https://github.com/OffchainLabs/token-bridge-contracts/blob/main/contracts/tokenbridge/libraries/gateway/GatewayRouter.sol
+    // Doc: https://docs.arbitrum.io/build-decentralized-apps/token-bridging/bridge-tokens-programmatically/how-to-bridge-tokens-standard
+    /// @notice Initiates a token withdrawal from L2 to L1.
+    /// @param _l1Token L1 address of token.
+    /// @param _to Destination address on L1.
+    /// @param _amount Amount of tokens to withdraw.
+    /// @param _maxGas Max gas for L2 execution (unused for L2 to L1, pass 0).
+    /// @param _gasPriceBid Gas price for L2 execution (unused for L2 to L1, pass 0).
+    /// @param _data Additional data for the withdrawal.
+    /// @return Encoded unique identifier for the withdrawal.
+    function outboundTransfer(address _l1Token, address _to, uint256 _amount, uint256 _maxGas,
+        uint256 _gasPriceBid, bytes calldata _data) external payable returns (bytes memory);
+}
+
+/// @dev Provided zero address.
+error ZeroAddress();
+
+/// @dev Reentrancy guard.
+error ReentrancyGuard();
+
+/// @title Bridge2BurnerArbitrum - Smart contract for collecting OLAS on Arbitrum chain and relaying them back to L1 OLAS Burner contract.
+contract Bridge2BurnerArbitrum is Bridge2Burner {
+    // L1 OLAS token address
+    address public immutable l1Olas;
+
+    /// @dev Bridge2BurnerArbitrum constructor.
+    /// @param _olas OLAS token address on L2.
+    /// @param _l2TokenRelayer L2 token relayer bridging contract address (L2GatewayRouter).
+    /// @param _l1Olas L1 OLAS token address.
+    constructor(address _olas, address _l2TokenRelayer, address _l1Olas) Bridge2Burner(_olas, _l2TokenRelayer) {
+        if (_l1Olas == address(0)) {
+            revert ZeroAddress();
+        }
+
+        l1Olas = _l1Olas;
+    }
+
+    /// @dev Relays OLAS to L1 Burner contract.
+    function relayToL1Burner() external virtual {
+        // Reentrancy guard
+        if (_locked > 1) {
+            revert ReentrancyGuard();
+        }
+        _locked = 2;
+
+        // Get OLAS amount to bridge
+        uint256 olasAmount = _getBalance();
+
+        // Approve OLAS for L2 gateway router
+        IToken(olas).approve(l2TokenRelayer, olasAmount);
+
+        // Relay OLAS to L1 Burner contract via Arbitrum L2 Gateway Router
+        IBridge(l2TokenRelayer).outboundTransfer(l1Olas, OLAS_BURNER, olasAmount, 0, 0, "");
+
+        _locked = 1;
+    }
+}

--- a/contracts/utils/Bridge2BurnerPolygon.sol
+++ b/contracts/utils/Bridge2BurnerPolygon.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Bridge2Burner} from "./Bridge2Burner.sol";
+
+// Bridge interface
+interface IBridge {
+    // Source: https://github.com/maticnetwork/pos-portal/blob/master/contracts/child/ChildERC20.sol
+    // Doc: https://docs.polygon.technology/pos/how-to/bridging/ethereum-polygon/erc20/
+    /// @notice Called when user wants to withdraw tokens back to root chain.
+    /// @dev Should burn user's tokens. This transaction will be verified when exiting on root chain.
+    /// @param amount Amount of tokens to withdraw.
+    function withdraw(uint256 amount) external;
+}
+
+/// @dev Reentrancy guard.
+error ReentrancyGuard();
+
+/// @title Bridge2BurnerPolygon - Smart contract for collecting OLAS on Polygon chain and relaying them back to L1 OLAS Burner contract.
+/// @dev After calling relayToL1Burner(), the exit must be finalized on L1 via RootChainManager.exit() with the burn proof.
+///      The withdrawn OLAS will be released to this contract's address on L1.
+contract Bridge2BurnerPolygon is Bridge2Burner {
+    /// @dev Bridge2BurnerPolygon constructor.
+    /// @param _olas OLAS token address on L2.
+    /// @param _l2TokenRelayer L2 token relayer bridging contract address (OLAS child token on Polygon).
+    constructor(address _olas, address _l2TokenRelayer) Bridge2Burner(_olas, _l2TokenRelayer) {}
+
+    /// @dev Relays OLAS to L1 Burner contract.
+    function relayToL1Burner() external virtual {
+        // Reentrancy guard
+        if (_locked > 1) {
+            revert ReentrancyGuard();
+        }
+        _locked = 2;
+
+        // Get OLAS amount to bridge
+        uint256 olasAmount = _getBalance();
+
+        // Withdraw OLAS to L1 via Polygon PoS bridge
+        // Source: https://docs.polygon.technology/pos/how-to/bridging/ethereum-polygon/erc20/#withdraw-tokens
+        // This burns tokens on L2; on L1, exit() via RootChainManager releases tokens to this contract's address
+        IBridge(l2TokenRelayer).withdraw(olasAmount);
+
+        _locked = 1;
+    }
+}

--- a/scripts/deployment/utils/deploy_00c_bridge2burner_polygon.sh
+++ b/scripts/deployment/utils/deploy_00c_bridge2burner_polygon.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+red=$(tput setaf 1)
+green=$(tput setaf 2)
+reset=$(tput sgr0)
+
+# Get globals file
+globals="$(dirname "$0")/globals_$1.json"
+if [ ! -f $globals ]; then
+  echo "${red}!!! $globals is not found${reset}"
+  exit 0
+fi
+
+# Read variables using jq
+contractVerification=$(jq -r '.contractVerification' $globals)
+useLedger=$(jq -r '.useLedger' $globals)
+derivationPath=$(jq -r '.derivationPath' $globals)
+chainId=$(jq -r '.chainId' $globals)
+networkURL=$(jq -r '.networkURL' $globals)
+
+# Check for Polygon keys only since on other networks those are not needed
+if [ $chainId == 137 ]; then
+  API_KEY=$ALCHEMY_API_KEY_MATIC
+  if [ "$API_KEY" == "" ]; then
+      echo "set ALCHEMY_API_KEY_MATIC env variable"
+      exit 0
+  fi
+elif [ $chainId == 80002 ]; then
+    API_KEY=$ALCHEMY_API_KEY_AMOY
+    if [ "$API_KEY" == "" ]; then
+        echo "set ALCHEMY_API_KEY_AMOY env variable"
+        exit 0
+    fi
+fi
+
+olasAddress=$(jq -r '.olasAddress' $globals)
+
+contractName="Bridge2BurnerPolygon"
+contractPath="contracts/utils/$contractName.sol:$contractName"
+constructorArgs="$olasAddress $olasAddress"
+contractArgs="$contractPath --constructor-args $constructorArgs"
+
+# Get deployer based on the ledger flag
+if [ "$useLedger" == "true" ]; then
+  walletArgs="-l --mnemonic-derivation-path $derivationPath"
+  deployer=$(cast wallet address $walletArgs)
+else
+  echo "Using PRIVATE_KEY: ${PRIVATE_KEY:0:6}..."
+  walletArgs="--private-key $PRIVATE_KEY"
+  deployer=$(cast wallet address $walletArgs)
+fi
+
+# Deployment message
+echo "${green}Deploying from: $deployer${reset}"
+echo "RPC: $networkURL"
+echo "${green}Deployment of: $contractArgs${reset}"
+
+# Deploy the contract and capture the address
+execCmd="forge create --broadcast --rpc-url $networkURL$API_KEY $walletArgs $contractArgs"
+deploymentOutput=$($execCmd)
+bridge2BurnerAddress=$(echo "$deploymentOutput" | grep 'Deployed to:' | awk '{print $3}')
+
+# Get output length
+outputLength=${#bridge2BurnerAddress}
+
+# Check for the deployed address
+if [ $outputLength != 42 ]; then
+  echo "${red}!!! The contract was not deployed...${reset}"
+  exit 0
+fi
+
+# Write new deployed contract back into JSON
+echo "$(jq '. += {"bridge2BurnerAddress":"'$bridge2BurnerAddress'"}' $globals)" > $globals
+
+# Verify contract
+if [ "$contractVerification" == "true" ]; then
+  contractParams="$bridge2BurnerAddress $contractPath --constructor-args $(cast abi-encode "constructor(address,address)" $constructorArgs)"
+  echo "Verification contract params: $contractParams"
+
+  echo "${green}Verifying contract on Etherscan...${reset}"
+  forge verify-contract --chain-id "$chainId" --etherscan-api-key "$ETHERSCAN_API_KEY" $contractParams
+
+  blockscoutURL=$(jq -r '.blockscoutURL' $globals)
+  if [ "$blockscoutURL" != "null" ]; then
+    echo "${green}Verifying contract on Blockscout...${reset}"
+    forge verify-contract --verifier blockscout --verifier-url "$blockscoutURL/api" $contractParams
+  fi
+fi
+
+echo "${green}$contractName deployed at: $bridge2BurnerAddress${reset}"

--- a/scripts/deployment/utils/deploy_00d_bridge2burner_arbitrum.sh
+++ b/scripts/deployment/utils/deploy_00d_bridge2burner_arbitrum.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+red=$(tput setaf 1)
+green=$(tput setaf 2)
+reset=$(tput sgr0)
+
+# Get globals file
+globals="$(dirname "$0")/globals_$1.json"
+if [ ! -f $globals ]; then
+  echo "${red}!!! $globals is not found${reset}"
+  exit 0
+fi
+
+# Read variables using jq
+contractVerification=$(jq -r '.contractVerification' $globals)
+useLedger=$(jq -r '.useLedger' $globals)
+derivationPath=$(jq -r '.derivationPath' $globals)
+chainId=$(jq -r '.chainId' $globals)
+networkURL=$(jq -r '.networkURL' $globals)
+
+# Check for Polygon keys only since on other networks those are not needed
+if [ $chainId == 137 ]; then
+  API_KEY=$ALCHEMY_API_KEY_MATIC
+  if [ "$API_KEY" == "" ]; then
+      echo "set ALCHEMY_API_KEY_MATIC env variable"
+      exit 0
+  fi
+elif [ $chainId == 80002 ]; then
+    API_KEY=$ALCHEMY_API_KEY_AMOY
+    if [ "$API_KEY" == "" ]; then
+        echo "set ALCHEMY_API_KEY_AMOY env variable"
+        exit 0
+    fi
+fi
+
+olasAddress=$(jq -r '.olasAddress' $globals)
+l2GatewayRouterAddress=$(jq -r '.l2GatewayRouterAddress' $globals)
+l1OlasAddress=$(jq -r '.l1OlasAddress' $globals)
+
+contractName="Bridge2BurnerArbitrum"
+contractPath="contracts/utils/$contractName.sol:$contractName"
+constructorArgs="$olasAddress $l2GatewayRouterAddress $l1OlasAddress"
+contractArgs="$contractPath --constructor-args $constructorArgs"
+
+# Get deployer based on the ledger flag
+if [ "$useLedger" == "true" ]; then
+  walletArgs="-l --mnemonic-derivation-path $derivationPath"
+  deployer=$(cast wallet address $walletArgs)
+else
+  echo "Using PRIVATE_KEY: ${PRIVATE_KEY:0:6}..."
+  walletArgs="--private-key $PRIVATE_KEY"
+  deployer=$(cast wallet address $walletArgs)
+fi
+
+# Deployment message
+echo "${green}Deploying from: $deployer${reset}"
+echo "RPC: $networkURL"
+echo "${green}Deployment of: $contractArgs${reset}"
+
+# Deploy the contract and capture the address
+execCmd="forge create --broadcast --rpc-url $networkURL$API_KEY $walletArgs $contractArgs"
+deploymentOutput=$($execCmd)
+bridge2BurnerAddress=$(echo "$deploymentOutput" | grep 'Deployed to:' | awk '{print $3}')
+
+# Get output length
+outputLength=${#bridge2BurnerAddress}
+
+# Check for the deployed address
+if [ $outputLength != 42 ]; then
+  echo "${red}!!! The contract was not deployed...${reset}"
+  exit 0
+fi
+
+# Write new deployed contract back into JSON
+echo "$(jq '. += {"bridge2BurnerAddress":"'$bridge2BurnerAddress'"}' $globals)" > $globals
+
+# Verify contract
+if [ "$contractVerification" == "true" ]; then
+  contractParams="$bridge2BurnerAddress $contractPath --constructor-args $(cast abi-encode "constructor(address,address,address)" $constructorArgs)"
+  echo "Verification contract params: $contractParams"
+
+  echo "${green}Verifying contract on Etherscan...${reset}"
+  forge verify-contract --chain-id "$chainId" --etherscan-api-key "$ETHERSCAN_API_KEY" $contractParams
+
+  blockscoutURL=$(jq -r '.blockscoutURL' $globals)
+  if [ "$blockscoutURL" != "null" ]; then
+    echo "${green}Verifying contract on Blockscout...${reset}"
+    forge verify-contract --verifier blockscout --verifier-url "$blockscoutURL/api" $contractParams
+  fi
+fi
+
+echo "${green}$contractName deployed at: $bridge2BurnerAddress${reset}"

--- a/scripts/deployment/utils/globals_arbitrum_mainnet.json
+++ b/scripts/deployment/utils/globals_arbitrum_mainnet.json
@@ -9,6 +9,8 @@
   "gasPriceInGwei": "2",
   "bridgeMediatorAddress": "0x4d30F68F5AA342d296d4deE4bB1Cacca912dA70F",
   "olasAddress": "0x064F8B858C2A603e1b106a2039f5446D32dc81c1",
+  "l1OlasAddress": "0x0001A500A6B18995B03f44bb040A5fFc28E45CB0",
+  "l2GatewayRouterAddress": "0x5288c571Fd7aD117beA99bF60FE0846C4E84F933",
   "nativeTokenAddress": "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
   "balancerVaultAddress": "0xBA12222222228d8Ba445958a75a0704d566BF2C8",
   "balancerPoolId": "0xaf8912a3c4f55a8584b67df30ee0ddf0e60e01f80002000000000000000004fc",

--- a/test/BuyBackBurnerBalancerArbitrum.t.sol
+++ b/test/BuyBackBurnerBalancerArbitrum.t.sol
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Test, console} from "forge-std/Test.sol";
+import {Utils} from "./utils/Utils.sol";
+import {BalancerPriceOracle} from "../contracts/oracles/BalancerPriceOracle.sol";
+import {Bridge2BurnerArbitrum} from "../contracts/utils/Bridge2BurnerArbitrum.sol";
+import {BuyBackBurnerBalancer} from "../contracts/utils/BuyBackBurnerBalancer.sol";
+import {BuyBackBurnerProxy} from "../contracts/utils/BuyBackBurnerProxy.sol";
+import {IToken} from "../contracts/interfaces/IToken.sol";
+
+/// @dev Fork tests for BuyBackBurnerBalancer on Arbitrum.
+///      Run: forge test -f $FORK_ARBITRUM_NODE_URL --mc BuyBackBurnerBalancerArbitrum -vvv
+contract BaseSetup is Test {
+    Utils internal utils;
+    BalancerPriceOracle internal oracleV2;
+    Bridge2BurnerArbitrum internal bridge2Burner;
+    BuyBackBurnerBalancer internal buyBackBurner;
+
+    address payable[] internal users;
+    address internal deployer;
+    address internal dev;
+
+    // Arbitrum mainnet addresses
+    address internal constant OLAS = 0x064F8B858C2A603e1b106a2039f5446D32dc81c1;
+    address internal constant WETH = 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1;
+    address internal constant TIMELOCK = 0x4d30F68F5AA342d296d4deE4bB1Cacca912dA70F;
+    address internal constant L2_GATEWAY_ROUTER = 0x5288c571Fd7aD117beA99bF60FE0846C4E84F933;
+    address internal constant L1_OLAS = 0x0001A500A6B18995B03f44bb040A5fFc28E45CB0;
+    bytes32 internal constant POOL_ID = 0xaf8912a3c4f55a8584b67df30ee0ddf0e60e01f80002000000000000000004fc;
+    address internal constant BALANCER_VAULT = 0xBA12222222228d8Ba445958a75a0704d566BF2C8;
+
+    address internal constant USDC = 0xaf88d065e77c8cC2239327C5EDb3A432268e5831;
+
+    // Oracle parameters
+    uint256 internal constant maxOracleSlippageBps = 5000;
+    uint256 internal constant minTwapWindowSeconds = 900;
+    uint256 internal constant minUpdateIntervalSeconds = 900;
+    uint256 internal constant maxStalenessSeconds = 900;
+
+    // BuyBackBurner max slippage (used as BPS in oracle validatePrice, and as percentage in post-swap bounds)
+    uint256 internal constant maxBuyBackSlippage = 1000; // 10%
+
+    function setUp() public virtual {
+        utils = new Utils();
+        users = utils.createUsers(2);
+        deployer = users[0];
+        vm.label(deployer, "Deployer");
+        dev = users[1];
+        vm.label(dev, "Developer");
+
+        // Deploy V2 oracle
+        oracleV2 = new BalancerPriceOracle(
+            BALANCER_VAULT, POOL_ID, OLAS,
+            maxOracleSlippageBps, minTwapWindowSeconds, minUpdateIntervalSeconds, maxStalenessSeconds
+        );
+
+        // Warm up oracle: two observations needed so both prevObservation and lastObservation are populated.
+        // First observation fills lastObservation (prev stays {0,0}).
+        oracleV2.updatePrice();
+        // Warp past minUpdateInterval, second observation shifts last→prev and records new last.
+        vm.warp(block.timestamp + minUpdateIntervalSeconds);
+        oracleV2.updatePrice();
+
+        // Deploy Bridge2Burner with L2GatewayRouter and L1 OLAS address
+        bridge2Burner = new Bridge2BurnerArbitrum(OLAS, L2_GATEWAY_ROUTER, L1_OLAS);
+
+        // Deploy BuyBackBurnerBalancer implementation
+        BuyBackBurnerBalancer buyBackBurnerImpl = new BuyBackBurnerBalancer(address(bridge2Burner), TIMELOCK);
+
+        // Construct proxy init payload: (accounts, balancerPoolId, maxSlippage)
+        address[] memory accounts = new address[](4);
+        accounts[0] = OLAS;
+        accounts[1] = WETH;
+        accounts[2] = address(oracleV2);
+        accounts[3] = BALANCER_VAULT;
+
+        bytes memory initPayload =
+            abi.encodeWithSignature("initialize(bytes)", abi.encode(accounts, POOL_ID, maxBuyBackSlippage));
+
+        // Deploy proxy and wrap
+        BuyBackBurnerProxy proxy = new BuyBackBurnerProxy(address(buyBackBurnerImpl), initPayload);
+        buyBackBurner = BuyBackBurnerBalancer(payable(address(proxy)));
+
+        // Set V2 oracle mapping for WETH
+        address[] memory secondTokens = new address[](1);
+        secondTokens[0] = WETH;
+        address[] memory oracles = new address[](1);
+        oracles[0] = address(oracleV2);
+        buyBackBurner.setV2Oracles(secondTokens, oracles);
+    }
+}
+
+contract BuyBackBurnerBalancerArbitrum is BaseSetup {
+    function setUp() public override {
+        super.setUp();
+    }
+
+    /// @dev Proxy is correctly initialized.
+    function testDeployment() public view {
+        assertEq(buyBackBurner.olas(), OLAS);
+        assertEq(buyBackBurner.nativeToken(), WETH);
+        assertEq(buyBackBurner.maxSlippage(), maxBuyBackSlippage);
+        assertEq(buyBackBurner.bridge2Burner(), address(bridge2Burner));
+        assertEq(buyBackBurner.treasury(), TIMELOCK);
+        assertEq(buyBackBurner.mapV2Oracles(WETH), address(oracleV2));
+    }
+
+    /// @dev V2 buyBack swaps WETH for OLAS and sends to bridge2Burner.
+    function testBuyBack() public {
+        deal(WETH, address(buyBackBurner), 0.1 ether);
+
+        buyBackBurner.buyBack(WETH, 0.1 ether);
+
+        uint256 olasBal = IToken(OLAS).balanceOf(address(bridge2Burner));
+        assertGt(olasBal, 0);
+        console.log("OLAS at bridge2Burner:", olasBal);
+    }
+
+    /// @dev buyBack with zero balance reverts.
+    function testBuyBackZeroBalance() public {
+        vm.expectRevert();
+        buyBackBurner.buyBack(WETH, 1 ether);
+    }
+
+    /// @dev buyBack adjusts amount to full balance when requested amount exceeds it.
+    function testBuyBackAdjustsToBalance() public {
+        deal(WETH, address(buyBackBurner), 0.1 ether);
+
+        buyBackBurner.buyBack(WETH, 1 ether);
+
+        assertGt(IToken(OLAS).balanceOf(address(bridge2Burner)), 0);
+        assertEq(IToken(WETH).balanceOf(address(buyBackBurner)), 0);
+    }
+
+    /// @dev buyBack with zero amount uses full balance.
+    function testBuyBackZeroAmountUsesBalance() public {
+        deal(WETH, address(buyBackBurner), 0.1 ether);
+
+        buyBackBurner.buyBack(WETH, 0);
+
+        assertGt(IToken(OLAS).balanceOf(address(bridge2Burner)), 0);
+        assertEq(IToken(WETH).balanceOf(address(buyBackBurner)), 0);
+    }
+
+    /// @dev updateOraclePrice works through BuyBackBurner.
+    function testUpdateOraclePrice() public {
+        vm.warp(block.timestamp + minUpdateIntervalSeconds);
+
+        buyBackBurner.updateOraclePrice(WETH);
+
+        assertEq(buyBackBurner.mapAccountActivities(address(this)), 1);
+    }
+
+    /// @dev updateOraclePrice reverts when rate-limited.
+    function testUpdateOraclePriceRateLimited() public {
+        vm.warp(block.timestamp + minUpdateIntervalSeconds);
+        buyBackBurner.updateOraclePrice(WETH);
+
+        vm.expectRevert();
+        buyBackBurner.updateOraclePrice(WETH);
+    }
+
+    /// @dev setV2Oracles reverts for non-owner.
+    function testSetV2OraclesNotOwner() public {
+        address[] memory tokens = new address[](1);
+        tokens[0] = WETH;
+        address[] memory oracles = new address[](1);
+        oracles[0] = address(oracleV2);
+
+        vm.prank(dev);
+        vm.expectRevert();
+        buyBackBurner.setV2Oracles(tokens, oracles);
+    }
+
+    /// @dev transfer sends non-whitelisted token to treasury.
+    function testTransferToTreasury() public {
+        uint256 timelockBefore = IToken(USDC).balanceOf(TIMELOCK);
+        deal(USDC, address(buyBackBurner), 1000e6);
+
+        buyBackBurner.transfer(USDC);
+
+        assertEq(IToken(USDC).balanceOf(TIMELOCK) - timelockBefore, 1000e6);
+        assertEq(IToken(USDC).balanceOf(address(buyBackBurner)), 0);
+    }
+
+    /// @dev transfer reverts for whitelisted swap token (WETH has oracle mapped).
+    function testTransferWhitelistedTokenReverts() public {
+        deal(WETH, address(buyBackBurner), 1 ether);
+
+        vm.expectRevert();
+        buyBackBurner.transfer(WETH);
+    }
+
+    /// @dev Proxy can receive native ETH funds.
+    function testReceiveNativeFunds() public {
+        deal(address(this), 1 ether);
+        (bool success,) = address(buyBackBurner).call{value: 1 ether}("");
+        assertTrue(success);
+    }
+
+    /// @dev setV2Oracles reverts when secondToken is OLAS.
+    function testSetV2OraclesOLASReverts() public {
+        address[] memory tokens = new address[](1);
+        tokens[0] = OLAS;
+        address[] memory oracles = new address[](1);
+        oracles[0] = address(oracleV2);
+
+        vm.expectRevert();
+        buyBackBurner.setV2Oracles(tokens, oracles);
+    }
+
+    /// @dev transfer sends OLAS to bridge2Burner.
+    function testTransferOLASToBridge() public {
+        deal(OLAS, address(buyBackBurner), 1000 ether);
+
+        buyBackBurner.transfer(OLAS);
+
+        assertEq(IToken(OLAS).balanceOf(address(bridge2Burner)), 1000 ether);
+        assertEq(IToken(OLAS).balanceOf(address(buyBackBurner)), 0);
+    }
+
+    /// @dev transfer reverts on zero balance.
+    function testTransferZeroBalanceReverts() public {
+        vm.expectRevert();
+        buyBackBurner.transfer(USDC);
+    }
+
+    /// @dev changeOwner works for current owner.
+    function testChangeOwner() public {
+        buyBackBurner.changeOwner(dev);
+        assertEq(buyBackBurner.owner(), dev);
+    }
+
+    /// @dev changeOwner reverts for non-owner.
+    function testChangeOwnerNotOwner() public {
+        vm.prank(dev);
+        vm.expectRevert();
+        buyBackBurner.changeOwner(dev);
+    }
+
+    /// @dev Full flow: buyBack WETH then relay OLAS to L1 via Arbitrum L2 Gateway Router.
+    function testBuyBackAndRelay() public {
+        deal(WETH, address(buyBackBurner), 0.1 ether);
+
+        buyBackBurner.buyBack(WETH, 0.1 ether);
+
+        uint256 olasBal = IToken(OLAS).balanceOf(address(bridge2Burner));
+        assertGt(olasBal, 0);
+
+        // Mock ArbSys precompile at 0x64 (not available in fork environment)
+        // ArbSys.sendTxToL1(address,bytes) is called by the Arbitrum gateway to relay L2→L1 messages
+        vm.mockCall(
+            address(0x0000000000000000000000000000000000000064),
+            abi.encodeWithSignature("sendTxToL1(address,bytes)"),
+            abi.encode(uint256(1))
+        );
+
+        bridge2Burner.relayToL1Burner();
+
+        assertEq(IToken(OLAS).balanceOf(address(bridge2Burner)), 0);
+    }
+
+    /// @dev buyBack increments activity counter.
+    function testBuyBackActivityCounter() public {
+        deal(WETH, address(buyBackBurner), 0.1 ether);
+
+        buyBackBurner.buyBack(WETH, 0.1 ether);
+
+        assertEq(buyBackBurner.mapAccountActivities(address(this)), 1);
+    }
+
+    /// @dev buyBack reverts when oracle observation is stale.
+    function testBuyBackStaleOracle() public {
+        vm.warp(block.timestamp + maxStalenessSeconds + 1);
+
+        deal(WETH, address(buyBackBurner), 0.1 ether);
+
+        vm.expectRevert();
+        buyBackBurner.buyBack(WETH, 0.1 ether);
+    }
+}

--- a/test/BuyBackBurnerBalancerPolygon.t.sol
+++ b/test/BuyBackBurnerBalancerPolygon.t.sol
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Test, console} from "forge-std/Test.sol";
+import {Utils} from "./utils/Utils.sol";
+import {BalancerPriceOracle} from "../contracts/oracles/BalancerPriceOracle.sol";
+import {Bridge2BurnerPolygon} from "../contracts/utils/Bridge2BurnerPolygon.sol";
+import {BuyBackBurnerBalancer} from "../contracts/utils/BuyBackBurnerBalancer.sol";
+import {BuyBackBurnerProxy} from "../contracts/utils/BuyBackBurnerProxy.sol";
+import {IToken} from "../contracts/interfaces/IToken.sol";
+
+/// @dev Fork tests for BuyBackBurnerBalancer on Polygon.
+///      Run: forge test -f $FORK_POLYGON_NODE_URL --mc BuyBackBurnerBalancerPolygon -vvv
+contract BaseSetup is Test {
+    Utils internal utils;
+    BalancerPriceOracle internal oracleV2;
+    Bridge2BurnerPolygon internal bridge2Burner;
+    BuyBackBurnerBalancer internal buyBackBurner;
+
+    address payable[] internal users;
+    address internal deployer;
+    address internal dev;
+
+    // Polygon mainnet addresses
+    address internal constant OLAS = 0xFEF5d947472e72Efbb2E388c730B7428406F2F95;
+    address internal constant WMATIC = 0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270;
+    address internal constant TIMELOCK = 0x9338b5153AE39BB89f50468E608eD9d764B755fD;
+    bytes32 internal constant POOL_ID = 0x62309056c759c36879cde93693e7903bf415e4bc000200000000000000000d5f;
+    address internal constant BALANCER_VAULT = 0xBA12222222228d8Ba445958a75a0704d566BF2C8;
+
+    address internal constant USDC = 0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359;
+
+    // Oracle parameters
+    uint256 internal constant maxOracleSlippageBps = 5000;
+    uint256 internal constant minTwapWindowSeconds = 900;
+    uint256 internal constant minUpdateIntervalSeconds = 900;
+    uint256 internal constant maxStalenessSeconds = 900;
+
+    // BuyBackBurner max slippage (used as BPS in oracle validatePrice, and as percentage in post-swap bounds)
+    uint256 internal constant maxBuyBackSlippage = 1000; // 10%
+
+    function setUp() public virtual {
+        utils = new Utils();
+        users = utils.createUsers(2);
+        deployer = users[0];
+        vm.label(deployer, "Deployer");
+        dev = users[1];
+        vm.label(dev, "Developer");
+
+        // Deploy V2 oracle
+        oracleV2 = new BalancerPriceOracle(
+            BALANCER_VAULT, POOL_ID, OLAS,
+            maxOracleSlippageBps, minTwapWindowSeconds, minUpdateIntervalSeconds, maxStalenessSeconds
+        );
+
+        // Warm up oracle: two observations needed so both prevObservation and lastObservation are populated.
+        // First observation fills lastObservation (prev stays {0,0}).
+        oracleV2.updatePrice();
+        // Warp past minUpdateInterval, second observation shifts last→prev and records new last.
+        vm.warp(block.timestamp + minUpdateIntervalSeconds);
+        oracleV2.updatePrice();
+
+        // Deploy Bridge2Burner (l2TokenRelayer is OLAS itself for Polygon PoS withdrawTo)
+        bridge2Burner = new Bridge2BurnerPolygon(OLAS, OLAS);
+
+        // Deploy BuyBackBurnerBalancer implementation
+        BuyBackBurnerBalancer buyBackBurnerImpl = new BuyBackBurnerBalancer(address(bridge2Burner), TIMELOCK);
+
+        // Construct proxy init payload: (accounts, balancerPoolId, maxSlippage)
+        address[] memory accounts = new address[](4);
+        accounts[0] = OLAS;
+        accounts[1] = WMATIC;
+        accounts[2] = address(oracleV2);
+        accounts[3] = BALANCER_VAULT;
+
+        bytes memory initPayload =
+            abi.encodeWithSignature("initialize(bytes)", abi.encode(accounts, POOL_ID, maxBuyBackSlippage));
+
+        // Deploy proxy and wrap
+        BuyBackBurnerProxy proxy = new BuyBackBurnerProxy(address(buyBackBurnerImpl), initPayload);
+        buyBackBurner = BuyBackBurnerBalancer(payable(address(proxy)));
+
+        // Set V2 oracle mapping for WMATIC
+        address[] memory secondTokens = new address[](1);
+        secondTokens[0] = WMATIC;
+        address[] memory oracles = new address[](1);
+        oracles[0] = address(oracleV2);
+        buyBackBurner.setV2Oracles(secondTokens, oracles);
+    }
+}
+
+contract BuyBackBurnerBalancerPolygon is BaseSetup {
+    function setUp() public override {
+        super.setUp();
+    }
+
+    /// @dev Proxy is correctly initialized.
+    function testDeployment() public view {
+        assertEq(buyBackBurner.olas(), OLAS);
+        assertEq(buyBackBurner.nativeToken(), WMATIC);
+        assertEq(buyBackBurner.maxSlippage(), maxBuyBackSlippage);
+        assertEq(buyBackBurner.bridge2Burner(), address(bridge2Burner));
+        assertEq(buyBackBurner.treasury(), TIMELOCK);
+        assertEq(buyBackBurner.mapV2Oracles(WMATIC), address(oracleV2));
+    }
+
+    /// @dev V2 buyBack swaps WMATIC for OLAS and sends to bridge2Burner.
+    function testBuyBack() public {
+        deal(WMATIC, address(buyBackBurner), 100 ether);
+
+        buyBackBurner.buyBack(WMATIC, 100 ether);
+
+        uint256 olasBal = IToken(OLAS).balanceOf(address(bridge2Burner));
+        assertGt(olasBal, 0);
+        console.log("OLAS at bridge2Burner:", olasBal);
+    }
+
+    /// @dev buyBack with zero balance reverts.
+    function testBuyBackZeroBalance() public {
+        vm.expectRevert();
+        buyBackBurner.buyBack(WMATIC, 1 ether);
+    }
+
+    /// @dev buyBack adjusts amount to full balance when requested amount exceeds it.
+    function testBuyBackAdjustsToBalance() public {
+        deal(WMATIC, address(buyBackBurner), 100 ether);
+
+        buyBackBurner.buyBack(WMATIC, 1000 ether);
+
+        assertGt(IToken(OLAS).balanceOf(address(bridge2Burner)), 0);
+        assertEq(IToken(WMATIC).balanceOf(address(buyBackBurner)), 0);
+    }
+
+    /// @dev buyBack with zero amount uses full balance.
+    function testBuyBackZeroAmountUsesBalance() public {
+        deal(WMATIC, address(buyBackBurner), 100 ether);
+
+        buyBackBurner.buyBack(WMATIC, 0);
+
+        assertGt(IToken(OLAS).balanceOf(address(bridge2Burner)), 0);
+        assertEq(IToken(WMATIC).balanceOf(address(buyBackBurner)), 0);
+    }
+
+    /// @dev updateOraclePrice works through BuyBackBurner.
+    function testUpdateOraclePrice() public {
+        vm.warp(block.timestamp + minUpdateIntervalSeconds);
+
+        buyBackBurner.updateOraclePrice(WMATIC);
+
+        assertEq(buyBackBurner.mapAccountActivities(address(this)), 1);
+    }
+
+    /// @dev updateOraclePrice reverts when rate-limited.
+    function testUpdateOraclePriceRateLimited() public {
+        vm.warp(block.timestamp + minUpdateIntervalSeconds);
+        buyBackBurner.updateOraclePrice(WMATIC);
+
+        vm.expectRevert();
+        buyBackBurner.updateOraclePrice(WMATIC);
+    }
+
+    /// @dev setV2Oracles reverts for non-owner.
+    function testSetV2OraclesNotOwner() public {
+        address[] memory tokens = new address[](1);
+        tokens[0] = WMATIC;
+        address[] memory oracles = new address[](1);
+        oracles[0] = address(oracleV2);
+
+        vm.prank(dev);
+        vm.expectRevert();
+        buyBackBurner.setV2Oracles(tokens, oracles);
+    }
+
+    /// @dev transfer sends non-whitelisted token to treasury.
+    function testTransferToTreasury() public {
+        uint256 timelockBefore = IToken(USDC).balanceOf(TIMELOCK);
+        deal(USDC, address(buyBackBurner), 1000e6);
+
+        buyBackBurner.transfer(USDC);
+
+        assertEq(IToken(USDC).balanceOf(TIMELOCK) - timelockBefore, 1000e6);
+        assertEq(IToken(USDC).balanceOf(address(buyBackBurner)), 0);
+    }
+
+    /// @dev transfer reverts for whitelisted swap token (WMATIC has oracle mapped).
+    function testTransferWhitelistedTokenReverts() public {
+        deal(WMATIC, address(buyBackBurner), 1 ether);
+
+        vm.expectRevert();
+        buyBackBurner.transfer(WMATIC);
+    }
+
+    /// @dev Proxy can receive native funds.
+    function testReceiveNativeFunds() public {
+        deal(address(this), 1 ether);
+        (bool success,) = address(buyBackBurner).call{value: 1 ether}("");
+        assertTrue(success);
+    }
+
+    /// @dev setV2Oracles reverts when secondToken is OLAS.
+    function testSetV2OraclesOLASReverts() public {
+        address[] memory tokens = new address[](1);
+        tokens[0] = OLAS;
+        address[] memory oracles = new address[](1);
+        oracles[0] = address(oracleV2);
+
+        vm.expectRevert();
+        buyBackBurner.setV2Oracles(tokens, oracles);
+    }
+
+    /// @dev transfer sends OLAS to bridge2Burner.
+    function testTransferOLASToBridge() public {
+        deal(OLAS, address(buyBackBurner), 1000 ether);
+
+        buyBackBurner.transfer(OLAS);
+
+        assertEq(IToken(OLAS).balanceOf(address(bridge2Burner)), 1000 ether);
+        assertEq(IToken(OLAS).balanceOf(address(buyBackBurner)), 0);
+    }
+
+    /// @dev transfer reverts on zero balance.
+    function testTransferZeroBalanceReverts() public {
+        vm.expectRevert();
+        buyBackBurner.transfer(USDC);
+    }
+
+    /// @dev changeOwner works for current owner.
+    function testChangeOwner() public {
+        buyBackBurner.changeOwner(dev);
+        assertEq(buyBackBurner.owner(), dev);
+    }
+
+    /// @dev changeOwner reverts for non-owner.
+    function testChangeOwnerNotOwner() public {
+        vm.prank(dev);
+        vm.expectRevert();
+        buyBackBurner.changeOwner(dev);
+    }
+
+    /// @dev Full flow: buyBack WMATIC then relay OLAS to L1 via Polygon PoS bridge.
+    function testBuyBackAndRelay() public {
+        deal(WMATIC, address(buyBackBurner), 100 ether);
+
+        buyBackBurner.buyBack(WMATIC, 100 ether);
+
+        uint256 olasBal = IToken(OLAS).balanceOf(address(bridge2Burner));
+        assertGt(olasBal, 0);
+
+        bridge2Burner.relayToL1Burner();
+
+        assertEq(IToken(OLAS).balanceOf(address(bridge2Burner)), 0);
+    }
+
+    /// @dev buyBack increments activity counter.
+    function testBuyBackActivityCounter() public {
+        deal(WMATIC, address(buyBackBurner), 100 ether);
+
+        buyBackBurner.buyBack(WMATIC, 100 ether);
+
+        assertEq(buyBackBurner.mapAccountActivities(address(this)), 1);
+    }
+
+    /// @dev buyBack reverts when oracle observation is stale.
+    function testBuyBackStaleOracle() public {
+        vm.warp(block.timestamp + maxStalenessSeconds + 1);
+
+        deal(WMATIC, address(buyBackBurner), 100 ether);
+
+        vm.expectRevert();
+        buyBackBurner.buyBack(WMATIC, 100 ether);
+    }
+}


### PR DESCRIPTION
  - Add Bridge2BurnerPolygon.sol — collects OLAS on Polygon and burns via the PoS bridge withdraw(). Exit must be finalized on L1 via RootChainManager.exit()
  - Add Bridge2BurnerArbitrum.sol — collects OLAS on Arbitrum and relays to L1 OLAS Burner via the L2GatewayRouter outboundTransfer(). Takes an additional l1Olas immutable for
  the L1 token address required by the Arbitrum gateway
  - Add deployment scripts deploy_00c_bridge2burner_polygon.sh and deploy_00d_bridge2burner_arbitrum.sh
  - Add l1OlasAddress and l2GatewayRouterAddress to globals_arbitrum_mainnet.json
  - Add fork tests BuyBackBurnerBalancerPolygon.t.sol (Polygon mainnet, 19/19 passing) and BuyBackBurnerBalancerArbitrum.t.sol (Arbitrum mainnet, 19/19 passing) covering full
  BuyBackBurner + Bridge2Burner relay flow
  - Arbitrum relay test mocks the ArbSys precompile (0x64) since it's unavailable in fork environments
  - Update README.md and CLAUDE.md with new fork test commands