### PR TITLE
docs: update Tokenomics implementation address in configuration.json

### DIFF
--- a/docs/configuration.json
+++ b/docs/configuration.json
@@ -11,7 +11,7 @@
       {
         "name": "Tokenomics",
         "artifact": "abis/0.8.30/Tokenomics.json",
-        "address": "0x1ce191601e7f2777EEB797149d6e65aE40dF0e93"
+        "address": "0xaeeC8bC8E5Fe28BC4dF2e9586b222924b8a0d5e9"
       },
       {
         "name": "TokenomicsProxy",


### PR DESCRIPTION
Completes the documentation side of the governance activation (autonolas-governance proposal executed in [`0x1ea31f…b0168`](https://etherscan.io/tx/0x1ea31f9979e39a288a09aadabb1db1e4e76a124bb9f825cb07b4829bb46b0168)), whose part F upgraded the Tokenomics implementation behind the `TokenomicsProxy`.

## Change
- `docs/configuration.json`: `Tokenomics` address `0x1ce191601e7f2777EEB797149d6e65aE40dF0e93` → **`0xaeeC8bC8E5Fe28BC4dF2e9586b222924b8a0d5e9`** (the new post-audit implementation, `VERSION()` = `1.3.0`).

The `TokenomicsProxy` entry (`0xc096…e300`) is unchanged.

## Why no ABI change
`abis/0.8.30/Tokenomics.json` already matches the deployed implementation — verified against mainnet:
- `TokenomicsProxy.tokenomicsImplementation()` = `0xaeeC8…d5e9`, `VERSION()` = `1.3.0`.
- The committed ABI is byte-identical to a fresh compile of `contracts/Tokenomics.sol` (108 entries each).
- The deployed implementation's runtime code body (excluding the metadata trailer) equals that fresh compile, i.e. the on-chain impl is the current `main` source.

So only the address required updating.