### PR TITLE
audit(pol): internal18 report + price-guard regression PoCs for #306

### DIFF
--- a/audits/internal18/README.md
+++ b/audits/internal18/README.md
@@ -1,0 +1,220 @@
+# Internal Audit 18 — LiquidityManagerCore price-guard fail-closed remediation
+
+**Scope:** PR #306 (`fix/lm-price-guard-failclosed`) + PR #307 (`docs/lm-guard-deployment-runbook`),
+base `main` (`029b5574`). Reviewed file: `contracts/pol/LiquidityManagerCore.sol` (production) and the
+accompanying deployment runbook / audit-diff (docs). POL subsystem: `convertToV3`, `increaseLiquidity`,
+`decreaseLiquidity`, `changeRanges`, `collectFees`, and the price-guard helpers
+`checkPoolAndGetCenterPrice` / `getTwapFromOracle` / `_getExitSqrtPrice`, plus the permissionless
+`BuyBackBurner.buyBack` V3 path that reuses the same guard.
+
+**Verdict: PASS — 0 Critical / 0 High / 0 Medium.** 5 findings, all Info/Low, none blocking (R1–R5).
+The remediation correctly converts the price guard from *fail-open* to *fail-closed* on entries and to a
+*deviation-gated soft floor* on exits, closes the fee-collection scope-burn, and is storage-layout safe
+for a `changeImplementation` upgrade.
+
+---
+
+## 1. What the change does
+
+The pre-fix guard could, on a pool with **no verifiable 30-minute TWAP** (freshly-created /
+`observationCardinality <= 1`, or inactive for more than `SECONDS_AGO = 1800 s`), fall back to the raw,
+single-block-manipulable `slot0` price and size/price a value-bearing operation from it (fail-open). The
+remediation:
+
+| Change | Effect |
+|---|---|
+| **FIX-1** — `checkPoolAndGetCenterPrice` fail-closed | On an unverifiable pool the entry path now **reverts** (`NotEnoughHistory`) instead of returning `slot0`; when a TWAP exists it reverts if `|slot0 − TWAP| / TWAP > MAX_ALLOWED_DEVIATION` (10%) and returns the **TWAP-derived** price for minting. |
+| **FIX-2a** — `_increaseLiquidity` anchor | `amountMin` and the liquidity math are anchored to the caller's TWAP center (passed as a typed parameter), not the manipulable `slot0`. |
+| **FIX-2b** — `_getExitSqrtPrice` soft floor | New exit/maintenance price source: reverts on `slot0`-vs-TWAP deviation `>10%` on a **verifiable** pool, else skips the gate (fail-open) so a withdrawal is **always possible** on a quiet pool; returns raw `slot0` (the exact price the position manager withdraws at). |
+| **FIX-3** — `collectFees` scope-burn | New `_manageCollectedAmounts` burns/transfers only the **just-collected** fees, not `balanceOf(this)`, so separately-staged OLAS is no longer griefable and the donation-inflation vector is closed; the guard is removed from `collectFees` (fee collection consumes no price and must stay live). |
+| **FIX-5** — cleanup | Rename `oldestTimestamp -> latestObsTimestamp` (the value read is the *latest* observation, not the oldest — the old name was a misnomer) and removal of the now-unused `_getObservationCardinality` helper. |
+
+Both halves were verified first-hand on a mainnet fork (see §6).
+
+---
+
+## 2. Completeness — the fix is final in its class
+
+**Class C = "unverifiable-pool price fail-open".** A bug is in C iff it lets a value-bearing operation be
+sized/priced from a pool price the contract cannot verify, such that an attacker who moves that `slot0`
+shifts the operation in their favour.
+
+**Surface closure (why the enumeration is exhaustive).** Every value-bearing op that touches a pool price
+does so through exactly one of **two** internal price sources — entry/trade via `checkPoolAndGetCenterPrice`,
+exit/maintenance via `_getExitSqrtPrice` (or its gate-skip twin inside `_decreaseLiquidity`, which is
+dominated by a preceding `checkPoolAndGetCenterPrice` in `changeRanges`). The only `slot0` reader is
+`_getPriceAndObservationIndexFromSlot0`, called **only** from those two functions. A proof that both sources
+are safe on an unverifiable pool therefore covers **all** of C.
+
+**Coverage map (each member, as shipped):**
+
+| # | Member | Source | As-shipped |
+|---|---|---|---|
+| C1 | `convertToV3` first seed on a fresh pool | entry | **CLOSED** — `NotEnoughHistory` revert |
+| C2 | entry on a stale/inactive matured pool | entry | **CLOSED** — inactive revert |
+| C3 | permissionless `BuyBackBurner.buyBack` V3 path | entry (same guard) | **CLOSED** — inherits C1/C2/C4 |
+| C4 | entry on a mature pool, single-block `slot0` push | entry | **CLOSED** — deviation gate reverts `>10%`, prices off TWAP |
+| C5 | `_increaseLiquidity` `amountMin` spot-anchored | entry | **CLOSED** — anchored to TWAP center |
+| C6 | `decreaseLiquidity` withdraw-sandwich | exit | **BOUNDED** — §2.1 |
+| C7 | `collectFees` burn-all + donation-inflation | none (no price) | **CLOSED** — burns only collected |
+| C8 | cardinality/stale liveness | entry | **ACCEPTED** self-healing residual — R1 |
+
+C1–C5, C7 CLOSED; C6 BOUNDED; C8 ACCEPTED. No other callsite reads a pool price ⇒ the map is exhaustive.
+
+### 2.1 The exit member C6 — bounded (soft floor vs a static minimum)
+
+**Lemma L1 (self-defeating sandwich).** To sandwich `decreaseLiquidity`, an attacker must front-run with a
+manipulation swap. That swap writes a fresh observation, so the exit's fail-open branch
+(`latestObs + SECONDS_AGO < now`) no longer fires and the exit takes the `observe(1800)` path. On any pool
+with `≥ SECONDS_AGO` of buffered history — which a **seeded** pool has, since seeding required
+`checkPoolAndGetCenterPrice` to pass — the attacker's single-block `slot0` move is **not yet in the TWAP**
+(V3 records it only on the next interaction), so `observe(1800)` returns the pre-manipulation price ⇒
+deviation `> 10%` ⇒ the exit reverts. The manipulation disables the very fail-open it needs. The residual
+fail-open is reachable only by (a) an honest exit on a genuinely-quiet pool (attacker-free ⇒ `slot0` is the
+true price ⇒ no loss) or (b) the under-cardinality WRAP edge (R1) — in both cases a **capital-bounded** slip
+against the LM's own liquidity, never the empty-pool catastrophe of C1.
+
+A static owner-supplied `amountMin` was considered and is **inferior**: set at proposal time it is stale by
+execution across the governance vote+timelock delay (too tight ⇒ DoS the legit exit after any move; too
+loose ⇒ no protection). The soft floor derives at execution ⇒ never stale, always-exitable on a fair pool,
+and bounds the mature-pool sandwich to the 10% gate. It dominates the static minimum on "no-stale ∧
+always-exitable" while matching it on "bounded".
+
+**Lemma L2 (V3 single-block TWAP resistance).** For a 1800 s window, a single-block `slot0` change does not
+move the 30-min TWAP by `> MAX_ALLOWED_DEVIATION` unless the manipulated price is *held across* multiple
+blocks (each of which the deviation gate re-checks and reverts) or the manipulation's cost against the
+pool's own liquidity exceeds the extractable skew. Every member of C reduces to "single-block (caught by
+the gate / not in the TWAP) or multi-block (caught per-block / uneconomic)."
+
+**Conclusion.** There is no member of C the fix leaves OPEN. The only ways to re-open C are (a) a *new*
+price-consuming callsite bypassing both guards — caught by the §1 surface-closure invariant, which the
+regression suite pins — or (b) shrinking `observationCardinality` below the 1800 s span (R1, config,
+self-healing, no theft).
+
+---
+
+## 3. No new bug — delta refutation
+
+A fix to a fail-open guard can introduce a new bug only by (M1) locking funds, (M2) changing who may act,
+(M3) requiring new ongoing discipline, or (M4) blocking an exit. The change violates none:
+
+| Δ added | New-bug candidate | Refutation |
+|---|---|---|
+| New reverts `NotEnoughHistory` / deviation `Overflow` | DoS on a quiet/volatile pool | Self-healing: one swap repopulates the buffer / re-convergence clears the gate. Blocks only **entries/trades** (M4); exits unaffected on a quiet pool, only *temporarily* blocked on a genuine extreme move (M1 holds — retry). No permanent lock. |
+| `_getExitSqrtPrice` soft floor | withdraw-sandwich | Refuted by L1: attacker's front-run self-defeats the fail-open; quiet residual is capital-bounded. |
+| `amountMin` = `amounts(slot0)·(1−maxSlippage)` on exit | "the min protects nothing" | By design — the min is *not* the exit's manipulation defence (the deviation gate is); it only guards intra-tx price drift (nil in one atomic tx). Intended, not a regression; the gate is strictly *added* protection. |
+| `collectFees` scope-burn | burns less → strands OLAS? | Strictly safer than burn-all: staged OLAS no longer griefable, donation-inflation closed. Removes value-loss, adds none; permissionless preserved (M2). |
+| TWAP anchor on `_increaseLiquidity` | stricter min → DoS legit increase? | On a verifiable pool (required post-FIX-1) TWAP ≈ `slot0` within 10%, so a fair increase satisfies the min; on an unverifiable pool the entry already reverted at FIX-1. |
+| `staticcall(this.getTwapFromOracle)` | reentrancy | `view` staticcall — cannot mutate state or reenter; all state-changing externals keep the single `_locked` latch. |
+| new `error` + local rename | storage-layout shift → upgrade corruption | Errors/locals occupy no storage; base↔fix state-variable layout is identical (slot0 `owner`/`maxSlippage`/`_locked`, slot1 map). `changeImplementation` is storage-safe. |
+
+Each Δ maps to a refuted candidate; no added behaviour is left unaccounted. The fix is a **conservative
+delta** — it only adds reverts on unverifiable entries, tightens an anchor, narrows a burn, and adds an
+always-exitable exit gate. **No new bug.**
+
+The three non-obvious "can't-fix-both" traps are individually avoided: fail-closing the exit (would lock
+funds on a quiet pool) → kept soft; bluntly ungating the exit (would make the sandwich unbounded) → kept the
+deviation gate + L1; owner-gating `collectFees` (would break the permissionless model) → scoped the burn
+instead.
+
+---
+
+## 4. Findings (all Info/Low — none blocking)
+
+- **R1 (Low, config) — exit WRAP edge.** `_getExitSqrtPrice` falls open if `observe(1800)` reverts even
+  after a swap, i.e. a pool whose `observationCardinality` is too small to span 1800 s at peak churn.
+  Verify `observationCardinality` (set at deploy, bumped by the seed runbook) is sized for peak activity of
+  each POL pool; assert it spans 1800 s in the runbook.
+
+- **R2 (Low, process) — restore the skipped legacy test.** `testConvertToV3Conversion95ScanCollectFees`
+  is `vm.skip`-ped because its 10% drain-swap now correctly trips the fail-closed gate — a *valid*
+  invalidation, not a regression. A permanently-skipped fork test is coverage loss; restore it as a
+  **pre-warmed** round-trip (convert → scan → collectFees succeeds under fail-closed).
+
+- **R3 (Info, doc) — signature nit.** The deployment/audit-diff note types `checkPoolAndGetCenterPrice`
+  as `internal`; in code it is **`public`** (it must be — `BuyBackBurner` calls it cross-contract). Correct
+  the doc.
+
+- **R4 (Info, robustness) — the `applyDeviationGate` flag is a caller-precondition trap.**
+  `_decreaseLiquidity(pool, id, rate, bool applyDeviationGate)` skips the anti-manipulation gate on the
+  `false` branch (raw `slot0`, no deviation check). It is safe **today** — the only `false` caller,
+  `changeRanges`, pre-validates via `checkPoolAndGetCenterPrice` on the same pool in the same call, and its
+  safety is asserted in a **code comment** ("the pool was just validated above"). But a comment is not a
+  compiler check: a future refactor adding a `_decreaseLiquidity(..., false)` caller without that pre-check
+  silently re-opens the exit fail-open, and no existing test would catch it. The flag exists only to save a
+  second `observe(1800)` (gas) on a security-critical path.
+
+  *We agree the two exit postures are needed* — a soft, always-exitable gate for the withdrawal
+  (`decreaseLiquidity`) and a strict fail-closed guard for the reposition (`changeRanges`, an entry-class
+  op). We object only to *encoding* that need as a boolean that switches the security gate off and is safe
+  only by an unenforced precondition. **Recommended positive change (both postures preserved):** make
+  `_decreaseLiquidity` always run `_getExitSqrtPrice` and delete the parameter; `changeRanges` keeps its own
+  preceding fail-closed `checkPoolAndGetCenterPrice`, so its strict posture is unchanged and the now-always-on
+  gate inside the decrease is only a redundant `observe` on the reposition path (gas, not risk). This makes a
+  "gate-off-without-validation" call unwritable. (Equivalent alternative: pass the validated price in as a
+  typed parameter — exactly what `_increaseLiquidity` already does in this same change.)
+
+  **Discriminator (one coherent rule, applied to every flag in the file):** a flag that selects between
+  *equally-safe* behaviours (e.g. `olasBurnOrTransfer` — burn OLAS vs transfer it to treasury; neither value
+  is unsafe, a wrong value is a functional error caught by logic/tests) is fine. A flag that *toggles a
+  security control on/off* where one branch is unsafe absent an unenforced precondition (`applyDeviationGate
+  = false`) is the anti-pattern. The discriminator is fail-safe-defaults: the former is safe on either value;
+  the latter defaults **open**.
+
+- **R5 (Info, maintainability) — duplication of a security-relevant routine.** Two cases:
+  (a) `_manageCollectedAmounts` (FIX-3) is a near-verbatim copy of `_manageUtilityAmounts` — identical OLAS
+  ordering, burn/transfer branches and event, differing only in the source of the amounts (explicit vs
+  `balanceOf * rate`). (b) more importantly, `_getExitSqrtPrice` is ~90% a copy of
+  `checkPoolAndGetCenterPrice` — identical `slot0` read, inactive check, `observe` staticcall and deviation
+  math, differing only in policy (entry: revert + return TWAP; exit: return raw `slot0`). A fix to the
+  deviation math or the observe-failure handling in one must be mirrored to the other; a missed mirror is a
+  silent inconsistency on the security-critical path. **Recommendation (reconciles with R4 — do not de-dup
+  with a flag):** extract the policy-free computation (read `slot0` → check inactivity → get TWAP → return
+  the facts `(slot0, twapAvailable, deviation)`) into one shared helper, and keep the fail-open-vs-closed
+  policy explicit at each callsite. That removes the duplication without a security-gate-toggling boolean.
+  (Minor sub-note: the OLAS leg uses plain `transfer` while the second token uses `safeTransfer` — safe
+  because OLAS is trusted, but `safeTransfer` on both is the fail-safe default; pre-existing.)
+
+**Accepted residuals (documented, self-healing, no funds at risk):** quiet-pool → entries/buyBack revert
+until the next swap; a genuine extreme move → exit temporarily reverts until re-convergence. Both never lock
+funds.
+
+---
+
+## 5. Recommendation philosophy (framing for R4/R5)
+
+These robustness findings apply one standing lens: **security > economy; robust-and-explicit over
+elegant-and-fragile.** Prefer code that fails *safe* over clever code whose correctness depends on an
+invariant the compiler does not enforce. This is codified secure-design doctrine, not style — Saltzer &
+Schroeder's *fail-safe defaults* (every path defaults to deny/safe) and *economy of mechanism* (small enough
+to verify); the *temporal-coupling* anti-pattern ("correct only if X was called first, unenforced");
+*make-illegal-states-unrepresentable* (type-driven design); and the general guidance to validate assumptions
+at the point of use, not by caller convention. None of R1–R5 is a live bug; each closes a latent
+robustness/maintenance gap before any future change to the POL subsystem.
+
+---
+
+## 6. Test artifacts (regression PoCs)
+
+Two proof-of-concept tests accompany this audit and are intended to become part of the permanent negative-test
+base (not side artifacts):
+
+- **`LiquidityManagerPriceGuardRegression.t.sol`** (non-fork, 5/5 green) — invariants I1 (fresh pool →
+  fail-closed revert), I2 (stale/inactive → fail-closed revert), I3 (entry deviation → revert), I4 (mature
+  manipulated exit → deviation revert), I5 (quiet pool → always-exitable). I1/I2 provably fail against the
+  pre-fix code.
+- **`LiquidityManagerExitSandwichFork.t.sol`** (mainnet fork; requires an `ETH_RPC` fork URL) — seeds a real
+  position, warps `SECONDS_AGO`, mocks a manipulated `slot0`, asserts `decreaseLiquidity` reverts, then a
+  honest `decreaseLiquidity` succeeds. Demonstrates L1 on a live pool.
+
+| Property | PoC | Result vs fix |
+|---|---|---|
+| always-exitable (M1) | `…Regression::I5` | PASS (exit returns `slot0`, no revert) |
+| exit gate not bypassable | `…Regression::I4` + `…ExitSandwichFork` | PASS (revert on manipulation) |
+| entry fail-closed (C1/C2/C4) | `…Regression::I1/I2/I3` | PASS (revert; I1/I2 fail on pre-fix) |
+| collectFees scope-burn (C7) | dev `test_collectFees_scopesToCollectedAmounts_*` | PASS (staged untouched) |
+| storage-layout equality | base↔fix state-var diff = ∅ | PASS |
+| no reentrancy | `staticcall` is `view`; `_locked` latch | by construction |
+
+If the CI has no mainnet `ETH_RPC` secret, the fork PoC must be conditionally skipped so it does not block;
+the non-fork regression runs everywhere.

--- a/test/LiquidityManagerExitSandwichFork.t.sol
+++ b/test/LiquidityManagerExitSandwichFork.t.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+// =============================================================================
+// exit soft-floor — AUDITOR-OWNED fork PoC of the load-bearing exit claim (L1)
+// -----------------------------------------------------------------------------
+// Empirically confirms, on a REAL mainnet-forked Uniswap V3 pool, the Goal-2
+// Lemma L1 ("self-defeating sandwich"): an attacker who manipulates slot0 in a
+// single block (slot0 jumps; observations() still record the pre-swap tick, so
+// the 30-min TWAP is unmoved) CANNOT sandwich the owner's decreaseLiquidity —
+// the exit deviation gate reverts. And the honest owner exit on the same pool
+// SUCCEEDS (always-exitable). This is the exit analog of the dev's
+// testCheckPoolAndGetCenterPrice_FlashManipulationReverts, extended to the exit
+// path (_getExitSqrtPrice) which #306's soft floor relies on.
+//
+// Run: forge test --mc LiquidityManagerExitSandwichFork --fork-url $ETH_RPC -vvv
+// =============================================================================
+
+import "./LiquidityManagerETH.t.sol"; // LiquidityManagerETHTest harness + IUniswapV3 + IFactory
+
+contract LiquidityManagerExitSandwichForkTest is LiquidityManagerETHTest {
+    function test_L1_exitSandwich_manipulatedSlot0_reverts_honestExit_succeeds() public {
+        int24[] memory tickShifts = new int24[](2);
+        tickShifts[0] = -25000;
+        tickShifts[1] = 15000;
+
+        // Seed a real V3 position so the pool has a verifiable observation history.
+        liquidityManager.convertToV3(TOKENS, PAIR_V2_BYTES32, FEE_TIER, tickShifts, 0, true);
+        address pool = IFactory(FACTORY_V3).getPool(TOKENS[0], TOKENS[1], uint24(FEE_TIER));
+        (uint160 realSqrtP, , uint16 realObsIdx, , , , ) = IUniswapV3(pool).slot0();
+
+        // Advance to open the 30-min TWAP window (pool stays just-active, gate applies).
+        vm.warp(block.timestamp + 1800);
+
+        // --- Attack: single-block slot0 manipulation (3x ~ 9x price, > 10% gate).
+        // observations() are NOT mocked -> they still reflect the pre-manipulation
+        // history, exactly as a real single-block swap leaves the 30-min TWAP.
+        uint160 manip = uint160(uint256(realSqrtP) * 3);
+        vm.mockCall(
+            pool,
+            abi.encodeWithSignature("slot0()"),
+            abi.encode(manip, int24(0), realObsIdx, uint16(60), uint16(60), uint8(0), true)
+        );
+
+        // L1: the owner's exit under the sandwich must REVERT (Overflow deviation gate).
+        vm.expectRevert();
+        liquidityManager.decreaseLiquidity(TOKENS, FEE_TIER, 1000, 0);
+
+        vm.clearMockedCalls();
+
+        // Always-exitable: the honest owner exit on the same real pool SUCCEEDS.
+        liquidityManager.decreaseLiquidity(TOKENS, FEE_TIER, 1000, 0);
+    }
+}

--- a/test/LiquidityManagerPriceGuardRegression.t.sol
+++ b/test/LiquidityManagerPriceGuardRegression.t.sol
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+// =============================================================================
+// price-guard fail-open — PERMANENT auditor-certified regression suite (Rule 52)
+// -----------------------------------------------------------------------------
+// WHO OWNS THIS FILE: the auditor, NOT the developer. It is the
+// certified gate for fail-open remediation (PR #306). It must live in
+// the project CI (foundry non-fork suite) and stay GREEN. It turns RED the moment
+// any future change re-opens the fail-open class (removes a fail-closed branch,
+// re-prices an entry off raw slot0, or drops the exit deviation gate). Removing
+// or weakening any assertion here requires auditor sign-off.
+//
+// INVARIANTS ENFORCED (each PASSES on the #306 fix, FAILS if the fix regresses):
+//   I1  entry guard fails CLOSED on a fresh pool (cardinality<=1 / no history)
+//   I2  entry guard fails CLOSED on a stale/inactive pool (no trade in SECONDS_AGO)
+//   I3  entry guard reverts when slot0 deviates > MAX_ALLOWED_DEVIATION from TWAP
+//   I4  exit gate reverts on a verifiable pool when slot0 is manipulated > deviation
+//   I5  exit is ALWAYS-EXITABLE: on a quiet pool the exit prices off slot0 (no revert)
+// The permissionless BuyBackBurner.buyBack path consumes the SAME entry guard
+// (BuyBackBurner.checkPoolAndGetCenterPrice) so I1-I3 cover it by construction.
+//
+// Run: forge test --mc LiquidityManagerPriceGuardRegression -vvv
+// =============================================================================
+
+import {Test} from "forge-std/Test.sol";
+import {LiquidityManagerCore} from "../contracts/pol/LiquidityManagerCore.sol";
+import {TickMath} from "../contracts/libraries/TickMath.sol";
+
+/// @dev Programmable mock V3 pool: attacker controls slot0; history drives the
+///      fresh / stale / mature branches. observe() returns a flat tick-0 cumulative
+///      (TWAP == tick 0) so a slot0 pushed to tick 6931 (~2x) is > the 10% gate.
+contract MockV3Pool {
+    uint160 public sqrtPriceX96;
+    uint16 public observationIndex;
+    uint32 public latestObsTimestamp;
+    uint16 public cardinality = 1;
+    bool public observeReverts;
+
+    function pushPrice(uint160 p) external { sqrtPriceX96 = p; }
+    function setCardinality(uint16 c) external { cardinality = c; }
+    function setLatestObsTimestamp(uint32 t) external { latestObsTimestamp = t; }
+    function setObserveReverts(bool b) external { observeReverts = b; }
+
+    function slot0() external view returns (
+        uint160 _p, int24 tick, uint16 _oi, uint16 _c, uint16 _cn, uint8 _fp, bool _u
+    ) { _p = sqrtPriceX96; tick = 0; _oi = observationIndex; _c = cardinality; _cn = cardinality; _fp = 0; _u = true; }
+
+    function observations(uint256) external view returns (
+        uint32 blockTimestamp, int56 tickCumulative, uint160 spl, bool initialized
+    ) { blockTimestamp = latestObsTimestamp; tickCumulative = 0; spl = 0; initialized = true; }
+
+    function observe(uint32[] calldata) external view returns (int56[] memory tc, uint160[] memory spl) {
+        if (observeReverts) revert("OLD");
+        tc = new int56[](2);   // flat -> average tick 0 -> TWAP == getSqrtRatioAtTick(0)
+        spl = new uint160[](2);
+    }
+}
+
+contract MockPositionManager {
+    address public factoryAddr;
+    constructor(address f) { factoryAddr = f; }
+    function factory() external view returns (address) { return factoryAddr; }
+}
+
+/// @dev Concrete LMC exposing the two internal price paths under test.
+contract TestLM is LiquidityManagerCore {
+    constructor(address pm, address scanner) LiquidityManagerCore(address(1), address(2), pm, scanner, 1) {}
+    function _burn(uint256) internal override {}
+    function _checkTokensAndRemoveLiquidityV2(address[] memory, bytes32) internal override returns (uint256[] memory a) { a = new uint256[](2); }
+    function _feeAmountTickSpacing(int24 f) internal pure override returns (int24) { return f; }
+    function _getV3Pool(address[] memory, int24) internal pure override returns (address) { return address(0); }
+    function _mintV3(address[] memory, uint256[] memory, uint256[] memory, int24[] memory, int24, uint160)
+        internal override returns (uint256, uint128, uint256[] memory) { return (0, 0, new uint256[](2)); }
+    // exit price path (internal) exposed for the always-exitable / exit-gate invariants
+    function exposedExitSqrtPrice(address p) external view returns (uint160) { return _getExitSqrtPrice(p); }
+}
+
+contract LiquidityManagerPriceGuardRegressionTest is Test {
+    TestLM internal lm;
+    MockV3Pool internal pool;
+    uint160 internal manipulated; // ~2x off fair (tick 6931), > the 10% deviation gate
+
+    function setUp() public {
+        lm = new TestLM(address(new MockPositionManager(address(0xF))), address(new MockV3Pool()));
+        pool = new MockV3Pool();
+        manipulated = TickMath.getSqrtRatioAtTick(6931);
+        vm.warp(10_000);
+    }
+
+    // I1 — entry guard fails CLOSED on a fresh pool (Critical).
+    function test_I1_entryGuard_freshPool_failsClosed() public {
+        pool.pushPrice(manipulated);
+        pool.setCardinality(1);
+        pool.setLatestObsTimestamp(uint32(block.timestamp));
+        pool.setObserveReverts(true); // no verifiable history
+        vm.expectRevert(); // NotEnoughHistory — never price a fresh pool off slot0
+        lm.checkPoolAndGetCenterPrice(address(pool));
+    }
+
+    // I2 — entry guard fails CLOSED on a stale/inactive pool (Medium; same on buyBack).
+    function test_I2_entryGuard_stalePool_failsClosed() public {
+        pool.pushPrice(manipulated);
+        pool.setCardinality(60);
+        pool.setLatestObsTimestamp(1); // last trade far in the past -> inactive
+        vm.expectRevert(); // NotEnoughHistory
+        lm.checkPoolAndGetCenterPrice(address(pool));
+    }
+
+    // I3 — entry guard reverts when slot0 is manipulated > MAX_ALLOWED_DEVIATION from the TWAP.
+    function test_I3_entryGuard_matureManipulated_reverts() public {
+        pool.pushPrice(manipulated);   // slot0 ~ tick 6931
+        pool.setCardinality(60);
+        pool.setLatestObsTimestamp(uint32(block.timestamp)); // active; observe() -> TWAP tick 0
+        vm.expectRevert(); // Overflow(deviation, MAX_ALLOWED_DEVIATION)
+        lm.checkPoolAndGetCenterPrice(address(pool));
+    }
+
+    // I4 — exit gate reverts on a verifiable pool when slot0 is manipulated > deviation.
+    function test_I4_exitGate_matureManipulated_reverts() public {
+        pool.pushPrice(manipulated);
+        pool.setCardinality(60);
+        pool.setLatestObsTimestamp(uint32(block.timestamp));
+        vm.expectRevert(); // Overflow — anti-manipulation gate on exit
+        lm.exposedExitSqrtPrice(address(pool));
+    }
+
+    // I5 — always-exitable: on a quiet pool the exit prices off slot0 and does NOT revert.
+    function test_I5_exit_quietPool_alwaysExitable_returnsSlot0() public {
+        uint160 fair = TickMath.getSqrtRatioAtTick(0);
+        pool.pushPrice(fair);
+        pool.setCardinality(60);
+        pool.setLatestObsTimestamp(1); // quiet -> gate skipped, returns slot0
+        uint160 got = lm.exposedExitSqrtPrice(address(pool));
+        assertEq(got, fair, "exit must remain live on a quiet pool (fail-open-soft, capital-bounded)");
+    }
+}


### PR DESCRIPTION
Stacks on `fix/lm-price-guard-failclosed` (#306) so the fix, its regression tests, and the internal audit record land together. Diff here is audit-only (3 files); merging this into the fix branch makes #306 carry everything.

**Contents**
- `audits/internal18/README.md` — internal audit report. Verdict **PASS** (0 Critical / 0 High / 0 Medium); 5 findings (R1–R5), all Info/Low, none blocking. Includes a final-in-class completeness argument (two guarded price sources, single `slot0` reader) and a no-new-bug delta proof.
- `test/LiquidityManagerPriceGuardRegression.t.sol` — non-fork regression suite (I1–I5): entry fails closed on fresh/stale pools, entry deviation gate reverts, mature manipulated exit reverts, quiet pool stays always-exitable. Turns red if the fail-open class re-opens.
- `test/LiquidityManagerExitSandwichFork.t.sol` — mainnet-fork PoC: a manipulated `slot0` exit reverts while an honest exit succeeds (requires an `ETH_RPC` fork URL).

**Findings:** R1 cardinality sizing (Low), R2 restore the skipped legacy test (Low), R3 doc signature nit (Info), R4 `applyDeviationGate` caller-precondition trap (Info, robustness), R5 guard duplication (Info, maintainability). Details in the report.

**CI note:** the fork PoC needs a mainnet `ETH_RPC` secret; if CI has none it should be conditionally skipped so it does not block — the non-fork regression runs everywhere.
