### PR TITLE
refactor(Dispenser): proxy-based Dispenser behind DispenserProxy

### DIFF
--- a/contracts/Dispenser.sol
+++ b/contracts/Dispenser.sol
@@ -228,6 +228,9 @@ error WrongAmount(uint256 provided, uint256 expected);
 /// @dev Caught reentrancy violation.
 error ReentrancyGuard();
 
+/// @dev The contract is already initialized.
+error AlreadyInitialized();
+
 /// @dev The contract is paused.
 error Paused();
 
@@ -263,7 +266,7 @@ contract Dispenser {
     }
 
     event OwnerUpdated(address indexed owner);
-    event TokenomicsUpdated(address indexed tokenomics);
+    event ImplementationUpdated(address indexed implementation);
     event TreasuryUpdated(address indexed treasury);
     event VoteWeightingUpdated(address indexed voteWeighting);
     event StakingParamsUpdated(uint256 maxNumClaimingEpochs, uint256 maxNumStakingTargets);
@@ -280,16 +283,28 @@ contract Dispenser {
     event AddNomineeHash(bytes32 indexed nomineeHash);
     event RemoveNomineeHash(bytes32 indexed nomineeHash);
 
+    // Dispenser proxy address slot
+    // keccak256("PROXY_DISPENSER") = "0x8bd249c73459f2c50400ebdc57436101fc7d9a76908baf1ba5be362b47b48f83"
+    bytes32 public constant PROXY_DISPENSER = 0x8bd249c73459f2c50400ebdc57436101fc7d9a76908baf1ba5be362b47b48f83;
     // Maximum chain Id as per EVM specs
     uint256 public constant MAX_EVM_CHAIN_ID = type(uint64).max / 2 - 36;
+
+    // Immutables live in the implementation bytecode, not proxy storage: they are re-settable by deploying
+    // a new implementation and calling changeImplementation. Every new implementation deploy must pass the
+    // correct constructor args — a wrong value silently rewires the proxy.
     uint256 public immutable defaultMinStakingWeight;
     uint256 public immutable defaultMaxStakingIncentive;
     // OLAS token address
     address public immutable olas;
+    // Tokenomics proxy address (stable by construction — the proxy address never changes)
+    address public immutable tokenomics;
     // Retainer address in bytes32 form
     bytes32 public immutable retainer;
     // Retainer hash of a Nominee struct composed of retainer address with block.chainid
     bytes32 public immutable retainerHash;
+
+    // Storage layout below is consumed via the DispenserProxy delegatecall and is FROZEN: never remove,
+    // reorder, retype or insert in the middle — new variables are appended strictly after the last mapping.
 
     // Max number of epochs to claim staking incentives for
     uint256 public maxNumClaimingEpochs;
@@ -302,8 +317,6 @@ contract Dispenser {
     // Pause state
     Pause public paused;
 
-    // Tokenomics contract address
-    address public tokenomics;
     // Treasury contract address
     address public treasury;
     // Vote Weighting contract address
@@ -320,36 +333,27 @@ contract Dispenser {
     // Mapping for epoch number => refunded all the staking inflation due to zero total voting power
     mapping(uint256 => bool) public mapZeroWeightEpochRefunded;
 
-    /// @dev Dispenser constructor.
+    /// @dev Dispenser implementation constructor: sets the implementation-bytecode immutables only.
+    /// @notice The mutable state is set via initialize() delegatecall-ed by the DispenserProxy constructor.
     /// @param _olas OLAS token address.
-    /// @param _tokenomics Tokenomics address.
-    /// @param _treasury Treasury address.
-    /// @param _voteWeighting Vote Weighting address.
+    /// @param _tokenomics Tokenomics proxy address.
+    /// @param _retainer Retainer address in bytes32 form.
+    /// @param _defaultMinStakingWeight Default min staking weight (bounded by uint16).
+    /// @param _defaultMaxStakingIncentive Default max staking incentive (bounded by uint96).
     constructor(
         address _olas,
         address _tokenomics,
-        address _treasury,
-        address _voteWeighting,
         bytes32 _retainer,
-        uint256 _maxNumClaimingEpochs,
-        uint256 _maxNumStakingTargets,
         uint256 _defaultMinStakingWeight,
         uint256 _defaultMaxStakingIncentive
     ) {
-        owner = msg.sender;
-        _locked = 1;
-        // Staking incentives must be paused at the time of deployment because staking parameters are not live yet
-        paused = Pause.StakingIncentivesPaused;
-
         // Check for at least one zero contract address
-        if (_olas == address(0) || _tokenomics == address(0) || _treasury == address(0) ||
-            _voteWeighting == address(0) || _retainer == 0) {
+        if (_olas == address(0) || _tokenomics == address(0) || _retainer == 0) {
             revert ZeroAddress();
         }
 
         // Check for zero value staking parameters
-        if (_maxNumClaimingEpochs == 0 || _maxNumStakingTargets == 0 || _defaultMinStakingWeight == 0 ||
-            _defaultMaxStakingIncentive == 0) {
+        if (_defaultMinStakingWeight == 0 || _defaultMaxStakingIncentive == 0) {
             revert ZeroValue();
         }
 
@@ -363,15 +367,69 @@ contract Dispenser {
 
         olas = _olas;
         tokenomics = _tokenomics;
-        treasury = _treasury;
-        voteWeighting = _voteWeighting;
 
         retainer = _retainer;
         retainerHash = keccak256(abi.encode(IVoteWeighting.Nominee(retainer, block.chainid)));
-        maxNumClaimingEpochs = _maxNumClaimingEpochs;
-        maxNumStakingTargets = _maxNumStakingTargets;
         defaultMinStakingWeight = _defaultMinStakingWeight;
         defaultMaxStakingIncentive = _defaultMaxStakingIncentive;
+    }
+
+    /// @dev Initializes the dispenser proxy storage.
+    /// @notice Delegatecall-ed by the DispenserProxy constructor; the caller becomes the owner.
+    /// @param _treasury Treasury address.
+    /// @param _voteWeighting Vote Weighting address.
+    /// @param _maxNumClaimingEpochs Maximum number of epochs to claim staking incentives for.
+    /// @param _maxNumStakingTargets Maximum number of staking targets on a single chain Id.
+    function initialize(
+        address _treasury,
+        address _voteWeighting,
+        uint256 _maxNumClaimingEpochs,
+        uint256 _maxNumStakingTargets
+    ) external {
+        // Check that the proxy storage has not been initialized yet
+        if (owner != address(0)) {
+            revert AlreadyInitialized();
+        }
+
+        // Check for at least one zero contract address
+        if (_treasury == address(0) || _voteWeighting == address(0)) {
+            revert ZeroAddress();
+        }
+
+        // Check for zero value staking parameters
+        if (_maxNumClaimingEpochs == 0 || _maxNumStakingTargets == 0) {
+            revert ZeroValue();
+        }
+
+        owner = msg.sender;
+        _locked = 1;
+        // Staking incentives must be paused at the time of deployment because staking parameters are not live yet
+        paused = Pause.StakingIncentivesPaused;
+
+        treasury = _treasury;
+        voteWeighting = _voteWeighting;
+        maxNumClaimingEpochs = _maxNumClaimingEpochs;
+        maxNumStakingTargets = _maxNumStakingTargets;
+    }
+
+    /// @dev Changes the dispenser implementation contract address behind the proxy.
+    /// @param implementation Dispenser implementation contract address.
+    function changeImplementation(address implementation) external {
+        // Check for the contract ownership
+        if (msg.sender != owner) {
+            revert OwnerOnly(msg.sender, owner);
+        }
+
+        // Check for the zero address
+        if (implementation == address(0)) {
+            revert ZeroAddress();
+        }
+
+        // Store the implementation address under the designated storage slot
+        assembly {
+            sstore(PROXY_DISPENSER, implementation)
+        }
+        emit ImplementationUpdated(implementation);
     }
 
     /// @dev Checkpoints specified staking target (nominee in Vote Weighting) and gets claimed epoch counters.
@@ -685,19 +743,14 @@ contract Dispenser {
     }
 
     /// @dev Changes various managing contract addresses.
-    /// @param _tokenomics Tokenomics address.
+    /// @notice The tokenomics address is an implementation immutable (it points at the stable TokenomicsProxy);
+    ///         changing it requires deploying a new implementation and calling changeImplementation.
     /// @param _treasury Treasury address.
     /// @param _voteWeighting Vote Weighting address.
-    function changeManagers(address _tokenomics, address _treasury, address _voteWeighting) external {
+    function changeManagers(address _treasury, address _voteWeighting) external {
         // Check for the contract ownership
         if (msg.sender != owner) {
             revert OwnerOnly(msg.sender, owner);
-        }
-
-        // Change Tokenomics contract address
-        if (_tokenomics != address(0)) {
-            tokenomics = _tokenomics;
-            emit TokenomicsUpdated(_tokenomics);
         }
 
         // Change Treasury contract address

--- a/contracts/proxies/DispenserProxy.sol
+++ b/contracts/proxies/DispenserProxy.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+/// @dev Proxy initialization failed.
+error InitializationFailed();
+
+/// @dev Zero address.
+error ZeroAddress();
+
+/// @dev Zero Value.
+error ZeroValue();
+
+/*
+* This is a proxy contract for dispenser.
+* Proxy implementation is created based on the Universal Upgradeable Proxy Standard (UUPS) EIP-1822.
+* The implementation address must be located in a unique storage slot of the proxy contract.
+* The upgrade logic must be located in the implementation contract.
+* Special dispenser implementation address slot is produced by hashing the "PROXY_DISPENSER" string
+* in order to make the slot unique.
+* The fallback() implementation for all the delegatecall-s is inspired by the Gnosis Safe set of contracts.
+*/
+
+/// @title DispenserProxy - Smart contract for dispenser proxy
+/// @author Aleksandr Kuperman - <aleksandr.kuperman@valory.xyz>
+/// @author Andrey Lebedev - <andrey.lebedev@valory.xyz>
+contract DispenserProxy {
+    // Code position in storage is keccak256("PROXY_DISPENSER") = "0x8bd249c73459f2c50400ebdc57436101fc7d9a76908baf1ba5be362b47b48f83"
+    bytes32 public constant PROXY_DISPENSER = 0x8bd249c73459f2c50400ebdc57436101fc7d9a76908baf1ba5be362b47b48f83;
+
+    /// @dev DispenserProxy constructor.
+    /// @param dispenser Dispenser implementation address.
+    /// @param dispenserData Dispenser initialization data.
+    constructor(address dispenser, bytes memory dispenserData) {
+        // Check for the zero address, since the delegatecall works even with the zero one
+        if (dispenser == address(0)) {
+            revert ZeroAddress();
+        }
+
+        // Check for the zero data
+        if (dispenserData.length == 0) {
+            revert ZeroValue();
+        }
+
+        assembly {
+            sstore(PROXY_DISPENSER, dispenser)
+        }
+        // Initialize proxy dispenser storage
+        (bool success, ) = dispenser.delegatecall(dispenserData);
+        if (!success) {
+            revert InitializationFailed();
+        }
+    }
+
+    /// @dev Delegatecall to all the incoming data.
+    fallback() external payable {
+        assembly {
+            let dispenser := sload(PROXY_DISPENSER)
+            // Otherwise continue with the delegatecall to the dispenser implementation
+            calldatacopy(0, 0, calldatasize())
+            let success := delegatecall(gas(), dispenser, 0, calldatasize(), 0, 0)
+            returndatacopy(0, 0, returndatasize())
+            if eq(success, 0) {
+                revert(0, returndatasize())
+            }
+            return(0, returndatasize())
+        }
+    }
+}

--- a/test/Dispenser.t.sol
+++ b/test/Dispenser.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.30;
 import {Test} from "forge-std/Test.sol";
 import {Utils} from "./utils/Utils.sol";
 import {Dispenser} from "../contracts/Dispenser.sol";
+import {DispenserProxy} from "../contracts/proxies/DispenserProxy.sol";
 import "../contracts/Tokenomics.sol";
 import {TokenomicsProxy} from "../contracts/proxies/TokenomicsProxy.sol";
 import {Treasury} from "../contracts/Treasury.sol";
@@ -56,24 +57,32 @@ contract BaseSetup is Test {
         componentRegistry = new MockRegistry();
         agentRegistry = new MockRegistry();
         serviceRegistry = new MockRegistry();
-        dispenser = new Dispenser(address(olas), deployer, deployer, deployer, retainer, 100, 100, 100, 1 ether);
 
-        // Depository contract is irrelevant here, so we are using a deployer's address
-        // Correct tokenomics address will be added below
-        treasury = new Treasury(address(olas), deployer, deployer, address(dispenser));
+        // Depository and dispenser contracts are irrelevant at this point, so we are using a deployer's address
+        // Correct tokenomics and dispenser addresses will be added below
+        treasury = new Treasury(address(olas), deployer, deployer, deployer);
 
         Tokenomics tokenomicsMaster = new Tokenomics();
         // Depository contract is irrelevant here, so we are using a deployer's address
+        // Dispenser address is a placeholder until the dispenser proxy is deployed below
         bytes memory proxyData = abi.encodeWithSelector(tokenomicsMaster.initializeTokenomics.selector,
-            address(olas), address(treasury), deployer, address(dispenser), address(ve), epochLen,
+            address(olas), address(treasury), deployer, deployer, address(ve), epochLen,
             address(componentRegistry), address(agentRegistry), address(serviceRegistry), address(0));
         TokenomicsProxy tokenomicsProxy = new TokenomicsProxy(address(tokenomicsMaster), proxyData);
         tokenomics = Tokenomics(address(tokenomicsProxy));
 
-        // Change tokenomics address
-        treasury.changeManagers(address(tokenomics), address(0), address(0));
-        // Change the tokenomics and treasury addresses in the dispenser to correct ones
-        dispenser.changeManagers(address(tokenomics), address(treasury), address(0));
+        // Deploy dispenser implementation (tokenomics proxy address is an implementation immutable) and proxy
+        // Vote Weighting contract is irrelevant here, so we are using a deployer's address
+        Dispenser dispenserMaster = new Dispenser(address(olas), address(tokenomics), retainer, 100, 1 ether);
+        bytes memory dispenserData = abi.encodeWithSelector(dispenserMaster.initialize.selector,
+            address(treasury), deployer, 100, 100);
+        DispenserProxy dispenserProxy = new DispenserProxy(address(dispenserMaster), dispenserData);
+        dispenser = Dispenser(address(dispenserProxy));
+
+        // Change tokenomics and dispenser addresses in treasury
+        treasury.changeManagers(address(tokenomics), address(0), address(dispenser));
+        // Change the dispenser address in tokenomics to the correct one
+        tokenomics.changeManagers(address(0), address(0), address(dispenser));
 
         // Set treasury contract as a minter for OLAS
         olas.changeMinter(address(treasury));

--- a/test/DispenserDevIncentives.js
+++ b/test/DispenserDevIncentives.js
@@ -54,25 +54,19 @@ describe("DispenserDevIncentives", async () => {
         ve = await VE.deploy();
         await ve.deployed();
 
-        const Dispenser = await ethers.getContractFactory("Dispenser");
-        dispenser = await Dispenser.deploy(olas.address, deployer.address, deployer.address, deployer.address,
-            retainer, maxNumClaimingEpochs, maxNumStakingTargets, defaultMinStakingWeight, defaultMaxStakingIncentive);
-        await dispenser.deployed();
-
+        // Dispenser address is a placeholder until the dispenser proxy is deployed below
         const Treasury = await ethers.getContractFactory("Treasury");
-        treasury = await Treasury.deploy(olas.address, deployer.address, deployer.address, dispenser.address);
+        treasury = await Treasury.deploy(olas.address, deployer.address, deployer.address, deployer.address);
         await treasury.deployed();
-
-        // Update for the correct treasury contract
-        await dispenser.changeManagers(AddressZero, treasury.address, AddressZero);
 
         const tokenomicsFactory = await ethers.getContractFactory("Tokenomics");
         // Deploy master tokenomics contract
         const tokenomicsMaster = await tokenomicsFactory.deploy();
         await tokenomicsMaster.deployed();
 
+        // Dispenser address is a placeholder until the dispenser proxy is deployed below
         const proxyData = tokenomicsMaster.interface.encodeFunctionData("initializeTokenomics",
-            [olas.address, treasury.address, deployer.address, dispenser.address, ve.address, epochLen,
+            [olas.address, treasury.address, deployer.address, deployer.address, ve.address, epochLen,
                 componentRegistry.address, agentRegistry.address, serviceRegistry.address, AddressZero]);
         // Deploy tokenomics proxy based on the needed tokenomics initialization
         const TokenomicsProxy = await ethers.getContractFactory("TokenomicsProxy");
@@ -82,15 +76,31 @@ describe("DispenserDevIncentives", async () => {
         // Get the tokenomics proxy contract
         tokenomics = await ethers.getContractAt("Tokenomics", tokenomicsProxy.address);
 
+        // Deploy dispenser master implementation (tokenomics proxy address is an implementation immutable)
+        const Dispenser = await ethers.getContractFactory("Dispenser");
+        const dispenserMaster = await Dispenser.deploy(olas.address, tokenomics.address, retainer,
+            defaultMinStakingWeight, defaultMaxStakingIncentive);
+        await dispenserMaster.deployed();
+
+        // Deploy dispenser proxy; Vote Weighting contract is irrelevant here, so we are using a deployer's address
+        const dispenserData = dispenserMaster.interface.encodeFunctionData("initialize",
+            [treasury.address, deployer.address, maxNumClaimingEpochs, maxNumStakingTargets]);
+        const DispenserProxy = await ethers.getContractFactory("DispenserProxy");
+        const dispenserProxy = await DispenserProxy.deploy(dispenserMaster.address, dispenserData);
+        await dispenserProxy.deployed();
+
+        // Get the dispenser proxy contract
+        dispenser = await ethers.getContractAt("Dispenser", dispenserProxy.address);
+
         const Attacker = await ethers.getContractFactory("ReentrancyAttacker");
         attacker = await Attacker.deploy(dispenser.address, treasury.address);
         await attacker.deployed();
 
-        // Change the tokenomics and treasury addresses in the dispenser to correct ones
-        await dispenser.changeManagers(tokenomics.address, treasury.address, AddressZero);
+        // Update tokenomics and dispenser addresses in treasury
+        await treasury.changeManagers(tokenomics.address, AddressZero, dispenser.address);
 
-        // Update tokenomics address in treasury
-        await treasury.changeManagers(tokenomics.address, AddressZero, AddressZero);
+        // Update dispenser address in tokenomics
+        await tokenomics.changeManagers(AddressZero, AddressZero, dispenser.address);
 
         // Mint the initial balance
         await olas.mint(deployer.address, initialMint);
@@ -105,18 +115,18 @@ describe("DispenserDevIncentives", async () => {
 
             // Trying to change managers from a non-owner account address
             await expect(
-                dispenser.connect(account).changeManagers(deployer.address, deployer.address, deployer.address)
+                dispenser.connect(account).changeManagers(deployer.address, deployer.address)
             ).to.be.revertedWithCustomError(dispenser, "OwnerOnly");
 
-            // Changing treasury, tokenomics and vote weighting addresses
-            await dispenser.connect(deployer).changeManagers(deployer.address, deployer.address, deployer.address);
-            expect(await dispenser.tokenomics()).to.equal(deployer.address);
+            // Changing treasury and vote weighting addresses; tokenomics is an implementation immutable
+            const tokenomicsAddress = await dispenser.tokenomics();
+            await dispenser.connect(deployer).changeManagers(deployer.address, deployer.address);
             expect(await dispenser.treasury()).to.equal(deployer.address);
             expect(await dispenser.voteWeighting()).to.equal(deployer.address);
+            expect(await dispenser.tokenomics()).to.equal(tokenomicsAddress);
 
             // Trying to change to zero addresses and making sure nothing has changed
-            await dispenser.connect(deployer).changeManagers(AddressZero, AddressZero, AddressZero);
-            expect(await dispenser.tokenomics()).to.equal(deployer.address);
+            await dispenser.connect(deployer).changeManagers(AddressZero, AddressZero);
             expect(await dispenser.treasury()).to.equal(deployer.address);
             expect(await dispenser.voteWeighting()).to.equal(deployer.address);
 
@@ -142,40 +152,56 @@ describe("DispenserDevIncentives", async () => {
         it("Should fail if deploying a dispenser with a zero address", async function () {
             const Dispenser = await ethers.getContractFactory("Dispenser");
             await expect(
-                Dispenser.deploy(AddressZero, AddressZero, AddressZero, AddressZero, HashZero, 0, 0, 0, 0)
+                Dispenser.deploy(AddressZero, AddressZero, HashZero, 0, 0)
             ).to.be.revertedWithCustomError(dispenser, "ZeroAddress");
             await expect(
-                Dispenser.deploy(deployer.address, AddressZero, AddressZero, AddressZero, HashZero, 0, 0, 0, 0)
+                Dispenser.deploy(deployer.address, AddressZero, HashZero, 0, 0)
             ).to.be.revertedWithCustomError(dispenser, "ZeroAddress");
             await expect(
-                Dispenser.deploy(deployer.address, deployer.address, AddressZero, AddressZero, HashZero, 0, 0, 0, 0)
+                Dispenser.deploy(deployer.address, deployer.address, HashZero, 0, 0)
             ).to.be.revertedWithCustomError(dispenser, "ZeroAddress");
             await expect(
-                Dispenser.deploy(deployer.address, deployer.address, deployer.address, AddressZero, HashZero, 0, 0, 0, 0)
-            ).to.be.revertedWithCustomError(dispenser, "ZeroAddress");
-            await expect(
-                Dispenser.deploy(deployer.address, deployer.address, deployer.address, deployer.address, HashZero, 0, 0, 0, 0)
-            ).to.be.revertedWithCustomError(dispenser, "ZeroAddress");
-            await expect(
-                Dispenser.deploy(deployer.address, deployer.address, deployer.address, deployer.address, retainer, 0, 0, 0, 0)
+                Dispenser.deploy(deployer.address, deployer.address, retainer, 0, 0)
             ).to.be.revertedWithCustomError(dispenser, "ZeroValue");
             await expect(
-                Dispenser.deploy(deployer.address, deployer.address, deployer.address, deployer.address, retainer, 10, 0, 0, 0)
+                Dispenser.deploy(deployer.address, deployer.address, retainer, 10, 0)
             ).to.be.revertedWithCustomError(dispenser, "ZeroValue");
             await expect(
-                Dispenser.deploy(deployer.address, deployer.address, deployer.address, deployer.address, retainer, 10, 10, 0, 0)
-            ).to.be.revertedWithCustomError(dispenser, "ZeroValue");
-            await expect(
-                Dispenser.deploy(deployer.address, deployer.address, deployer.address, deployer.address, retainer, 10, 10, 10, 0)
-            ).to.be.revertedWithCustomError(dispenser, "ZeroValue");
-            await expect(
-                Dispenser.deploy(deployer.address, deployer.address, deployer.address, deployer.address, retainer, 10, 10,
-                    moreThanMaxUint96, moreThanMaxUint96)
+                Dispenser.deploy(deployer.address, deployer.address, retainer, moreThanMaxUint96, moreThanMaxUint96)
             ).to.be.revertedWithCustomError(dispenser, "Overflow");
             await expect(
-                Dispenser.deploy(deployer.address, deployer.address, deployer.address, deployer.address, retainer, 10, 10,
-                    10, moreThanMaxUint96)
+                Dispenser.deploy(deployer.address, deployer.address, retainer, 10, moreThanMaxUint96)
             ).to.be.revertedWithCustomError(dispenser, "Overflow");
+        });
+
+        it("Should fail when initializing with incorrect values or twice", async function () {
+            const Dispenser = await ethers.getContractFactory("Dispenser");
+            const dispenserMaster = await Dispenser.deploy(deployer.address, deployer.address, retainer, 10, 10);
+            await dispenserMaster.deployed();
+
+            await expect(
+                dispenserMaster.initialize(AddressZero, AddressZero, 0, 0)
+            ).to.be.revertedWithCustomError(dispenser, "ZeroAddress");
+            await expect(
+                dispenserMaster.initialize(deployer.address, AddressZero, 0, 0)
+            ).to.be.revertedWithCustomError(dispenser, "ZeroAddress");
+            await expect(
+                dispenserMaster.initialize(deployer.address, deployer.address, 0, 0)
+            ).to.be.revertedWithCustomError(dispenser, "ZeroValue");
+            await expect(
+                dispenserMaster.initialize(deployer.address, deployer.address, 10, 0)
+            ).to.be.revertedWithCustomError(dispenser, "ZeroValue");
+
+            // Initialize and check that a repeated initialization is not possible
+            await dispenserMaster.initialize(deployer.address, deployer.address, 10, 10);
+            await expect(
+                dispenserMaster.initialize(deployer.address, deployer.address, 10, 10)
+            ).to.be.revertedWithCustomError(dispenser, "AlreadyInitialized");
+
+            // The already-initialized dispenser proxy must not be re-initializable either
+            await expect(
+                dispenser.initialize(deployer.address, deployer.address, 10, 10)
+            ).to.be.revertedWithCustomError(dispenser, "AlreadyInitialized");
         });
 
         it("Should fail when trying to claim during the paused statke", async function () {

--- a/test/DispenserProxy.t.sol
+++ b/test/DispenserProxy.t.sol
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Test} from "forge-std/Test.sol";
+import {Dispenser, AlreadyInitialized, OwnerOnly, ZeroAddress, ZeroValue} from "../contracts/Dispenser.sol";
+import {DispenserProxy} from "../contracts/proxies/DispenserProxy.sol";
+
+/// @dev Proxy-lifecycle tests for the Dispenser behind DispenserProxy: initialization via the proxy
+///      constructor delegatecall, re-initialization protection, implementation upgrade via
+///      changeImplementation (owner-gated, state-preserving), and proxy constructor guards.
+///      Run: forge test --mc DispenserProxyTest -vvv
+contract DispenserProxyTest is Test {
+    event ImplementationUpdated(address indexed implementation);
+
+    bytes32 public constant PROXY_DISPENSER = 0x8bd249c73459f2c50400ebdc57436101fc7d9a76908baf1ba5be362b47b48f83;
+
+    address internal constant OLAS = address(0x01A5);
+    address internal constant TOKENOMICS = address(0x70e0);
+    address internal constant TREASURY = address(0x7EA5);
+    address internal constant VOTE_WEIGHTING = address(0x0e7e);
+    bytes32 internal constant RETAINER = bytes32(uint256(uint160(0xe7a1)));
+
+    Dispenser internal dispenserMaster;
+    Dispenser internal dispenser;
+
+    function setUp() public {
+        dispenserMaster = new Dispenser(OLAS, TOKENOMICS, RETAINER, 100, 1 ether);
+        bytes memory initData = abi.encodeWithSelector(Dispenser.initialize.selector,
+            TREASURY, VOTE_WEIGHTING, 10, 20);
+        DispenserProxy proxy = new DispenserProxy(address(dispenserMaster), initData);
+        dispenser = Dispenser(address(proxy));
+    }
+
+    // -----------------------------------------------------------------------
+    // Proxy constructor guards
+    // -----------------------------------------------------------------------
+
+    function test_proxyConstructor_zeroImplementation_reverts() public {
+        vm.expectRevert(abi.encodeWithSignature("ZeroAddress()"));
+        new DispenserProxy(address(0), abi.encode(uint256(1)));
+    }
+
+    function test_proxyConstructor_zeroData_reverts() public {
+        vm.expectRevert(abi.encodeWithSignature("ZeroValue()"));
+        new DispenserProxy(address(dispenserMaster), "");
+    }
+
+    function test_proxyConstructor_failedInit_reverts() public {
+        // Zero treasury address makes initialize revert -> proxy constructor reverts InitializationFailed
+        bytes memory badInit = abi.encodeWithSelector(Dispenser.initialize.selector,
+            address(0), VOTE_WEIGHTING, 10, 20);
+        vm.expectRevert(abi.encodeWithSignature("InitializationFailed()"));
+        new DispenserProxy(address(dispenserMaster), badInit);
+    }
+
+    // -----------------------------------------------------------------------
+    // Initialization through the proxy
+    // -----------------------------------------------------------------------
+
+    function test_initialize_setsStateAndImmutables() public {
+        // Proxy storage set by initialize; owner is the proxy deployer (this contract)
+        assertEq(dispenser.owner(), address(this), "owner");
+        assertEq(dispenser.treasury(), TREASURY, "treasury");
+        assertEq(dispenser.voteWeighting(), VOTE_WEIGHTING, "voteWeighting");
+        assertEq(dispenser.maxNumClaimingEpochs(), 10, "maxNumClaimingEpochs");
+        assertEq(dispenser.maxNumStakingTargets(), 20, "maxNumStakingTargets");
+        // Staking incentives are paused at deployment
+        assertEq(uint256(dispenser.paused()), uint256(Dispenser.Pause.StakingIncentivesPaused), "paused");
+
+        // Implementation immutables read through the proxy delegatecall
+        assertEq(dispenser.olas(), OLAS, "olas");
+        assertEq(dispenser.tokenomics(), TOKENOMICS, "tokenomics");
+        assertEq(dispenser.retainer(), RETAINER, "retainer");
+        assertEq(dispenser.defaultMinStakingWeight(), 100, "defaultMinStakingWeight");
+        assertEq(dispenser.defaultMaxStakingIncentive(), 1 ether, "defaultMaxStakingIncentive");
+
+        // The implementation address sits in the dedicated proxy slot
+        bytes32 rawImplementation = vm.load(address(dispenser), PROXY_DISPENSER);
+        assertEq(address(uint160(uint256(rawImplementation))), address(dispenserMaster), "implementation slot");
+    }
+
+    function test_initialize_proxyReinit_reverts() public {
+        vm.expectRevert(AlreadyInitialized.selector);
+        dispenser.initialize(TREASURY, VOTE_WEIGHTING, 10, 20);
+    }
+
+    function test_initialize_implDirectReinit_reverts() public {
+        // Direct initialization of the implementation's own storage is possible once (harmless), not twice
+        dispenserMaster.initialize(TREASURY, VOTE_WEIGHTING, 10, 20);
+        vm.expectRevert(AlreadyInitialized.selector);
+        dispenserMaster.initialize(TREASURY, VOTE_WEIGHTING, 10, 20);
+    }
+
+    // -----------------------------------------------------------------------
+    // changeImplementation
+    // -----------------------------------------------------------------------
+
+    function test_changeImplementation_notOwner_reverts() public {
+        address nonOwner = address(0xBAD);
+        vm.prank(nonOwner);
+        vm.expectRevert(abi.encodeWithSelector(OwnerOnly.selector, nonOwner, address(this)));
+        dispenser.changeImplementation(address(dispenserMaster));
+    }
+
+    function test_changeImplementation_zeroAddress_reverts() public {
+        vm.expectRevert(ZeroAddress.selector);
+        dispenser.changeImplementation(address(0));
+    }
+
+    function test_changeImplementation_swapsLogicAndPreservesState() public {
+        // Mutate proxy storage first so preservation is observable
+        dispenser.changeStakingParams(42, 84);
+
+        // New implementation with different immutables (models a fixed / re-parameterized build)
+        Dispenser newMaster = new Dispenser(OLAS, TOKENOMICS, RETAINER, 200, 2 ether);
+
+        vm.expectEmit(true, false, false, false, address(dispenser));
+        emit ImplementationUpdated(address(newMaster));
+        dispenser.changeImplementation(address(newMaster));
+
+        // Slot updated
+        bytes32 rawImplementation = vm.load(address(dispenser), PROXY_DISPENSER);
+        assertEq(address(uint160(uint256(rawImplementation))), address(newMaster), "implementation slot");
+
+        // Proxy storage preserved across the upgrade
+        assertEq(dispenser.owner(), address(this), "owner preserved");
+        assertEq(dispenser.treasury(), TREASURY, "treasury preserved");
+        assertEq(dispenser.voteWeighting(), VOTE_WEIGHTING, "voteWeighting preserved");
+        assertEq(dispenser.maxNumClaimingEpochs(), 42, "maxNumClaimingEpochs preserved");
+        assertEq(dispenser.maxNumStakingTargets(), 84, "maxNumStakingTargets preserved");
+        assertEq(uint256(dispenser.paused()), uint256(Dispenser.Pause.StakingIncentivesPaused), "paused preserved");
+
+        // Immutable reads now come from the new implementation bytecode
+        assertEq(dispenser.defaultMinStakingWeight(), 200, "new defaultMinStakingWeight");
+        assertEq(dispenser.defaultMaxStakingIncentive(), 2 ether, "new defaultMaxStakingIncentive");
+    }
+}

--- a/test/DispenserStakingIncentives.js
+++ b/test/DispenserStakingIncentives.js
@@ -70,30 +70,19 @@ describe("DispenserStakingIncentives", async () => {
         // Add a default implementation mocked as a proxy address itself
         await stakingProxyFactory.addImplementation(stakingInstance.address, stakingInstance.address);
 
-        const Dispenser = await ethers.getContractFactory("Dispenser");
-        dispenser = await Dispenser.deploy(olas.address, deployer.address, deployer.address, deployer.address,
-            retainer, maxNumClaimingEpochs, maxNumStakingTargets, defaultMinStakingWeight, defaultMaxStakingIncentive);
-        await dispenser.deployed();
-
-        // Vote Weighting mock
-        const VoteWeighting = await ethers.getContractFactory("MockVoteWeighting");
-        vw = await VoteWeighting.deploy(dispenser.address);
-        await vw.deployed();
-
+        // Dispenser address is a placeholder until the dispenser proxy is deployed below
         const Treasury = await ethers.getContractFactory("Treasury");
-        treasury = await Treasury.deploy(olas.address, deployer.address, deployer.address, dispenser.address);
+        treasury = await Treasury.deploy(olas.address, deployer.address, deployer.address, deployer.address);
         await treasury.deployed();
-
-        // Update for the correct treasury contract
-        await dispenser.changeManagers(AddressZero, treasury.address, AddressZero);
 
         const tokenomicsFactory = await ethers.getContractFactory("Tokenomics");
         // Deploy master tokenomics contract
         const tokenomicsMaster = await tokenomicsFactory.deploy();
         await tokenomicsMaster.deployed();
 
+        // Dispenser address is a placeholder until the dispenser proxy is deployed below
         const proxyData = tokenomicsMaster.interface.encodeFunctionData("initializeTokenomics",
-            [olas.address, treasury.address, deployer.address, dispenser.address, deployer.address, epochLen,
+            [olas.address, treasury.address, deployer.address, deployer.address, deployer.address, epochLen,
                 deployer.address, deployer.address, deployer.address, AddressZero]);
         // Deploy tokenomics proxy based on the needed tokenomics initialization
         const TokenomicsProxy = await ethers.getContractFactory("TokenomicsProxy");
@@ -103,11 +92,35 @@ describe("DispenserStakingIncentives", async () => {
         // Get the tokenomics proxy contract
         tokenomics = await ethers.getContractAt("Tokenomics", tokenomicsProxy.address);
 
-        // Change the tokenomics and treasury addresses in the dispenser to correct ones
-        await dispenser.changeManagers(tokenomics.address, treasury.address, vw.address);
+        // Deploy dispenser master implementation (tokenomics proxy address is an implementation immutable)
+        const Dispenser = await ethers.getContractFactory("Dispenser");
+        const dispenserMaster = await Dispenser.deploy(olas.address, tokenomics.address, retainer,
+            defaultMinStakingWeight, defaultMaxStakingIncentive);
+        await dispenserMaster.deployed();
 
-        // Update tokenomics address in treasury
-        await treasury.changeManagers(tokenomics.address, AddressZero, AddressZero);
+        // Deploy dispenser proxy; Vote Weighting address is a placeholder until the mock is deployed below
+        const dispenserData = dispenserMaster.interface.encodeFunctionData("initialize",
+            [treasury.address, deployer.address, maxNumClaimingEpochs, maxNumStakingTargets]);
+        const DispenserProxy = await ethers.getContractFactory("DispenserProxy");
+        const dispenserProxy = await DispenserProxy.deploy(dispenserMaster.address, dispenserData);
+        await dispenserProxy.deployed();
+
+        // Get the dispenser proxy contract
+        dispenser = await ethers.getContractAt("Dispenser", dispenserProxy.address);
+
+        // Vote Weighting mock
+        const VoteWeighting = await ethers.getContractFactory("MockVoteWeighting");
+        vw = await VoteWeighting.deploy(dispenser.address);
+        await vw.deployed();
+
+        // Change the vote weighting address in the dispenser to the correct one
+        await dispenser.changeManagers(AddressZero, vw.address);
+
+        // Update tokenomics and dispenser addresses in treasury
+        await treasury.changeManagers(tokenomics.address, AddressZero, dispenser.address);
+
+        // Update dispenser address in tokenomics
+        await tokenomics.changeManagers(AddressZero, AddressZero, dispenser.address);
 
         // Mint the initial balance
         await olas.mint(deployer.address, initialMint);


### PR DESCRIPTION
First PR of the Dispenser rework (PR-A of the series): makes the Dispenser **proxy-based**, following the `TokenomicsProxy` / `LiquidityManagerProxy` pattern, so future Dispenser logic fixes become one-tx implementation swaps behind a **stable address** instead of a whole-stack redeploy. The L1 deposit processors bind `l1Dispenser` immutably and the L2 target dispensers bind their L1 processor immutably — with a stable proxy address those bindings never have to change again.

**Contents**
- `contracts/proxies/DispenserProxy.sol` — EIP-1822-style proxy: implementation slot `keccak256("PROXY_DISPENSER")`, `constructor(implementation, initData)` delegatecall-init, payable Gnosis-Safe-style fallback (the Dispenser has payable claim functions).
- `contracts/Dispenser.sol`:
  - Constructor now sets **bytecode immutables only**: `olas`, `tokenomics`, `retainer`/`retainerHash`, `defaultMinStakingWeight`, `defaultMaxStakingIncentive`. Behind a proxy these are re-settable via an implementation swap, so "immutable" no longer means locked forever — every impl deploy must pass the correct constructor args (documented in-code).
  - `tokenomics` promoted to immutable — it points at the stable TokenomicsProxy and is read on every claim (hot path, zero-SLOAD). `changeManagers` drops its tokenomics param; `treasury` / `voteWeighting` stay mutable.
  - New `initialize(treasury, voteWeighting, maxNumClaimingEpochs, maxNumStakingTargets)` guarded by `AlreadyInitialized`; new owner-gated `changeImplementation(address)` (same shape/name as LiquidityManagerCore / BuyBackBurner).
  - Storage layout frozen append-only (no gap — flat contract, Tokenomics convention).
- Tests: new `test/DispenserProxy.t.sol` (9 tests — proxy guards, init/re-init, upgrade preserving state while swapping logic/immutables); `test/Dispenser.t.sol` + both hardhat Dispenser suites now run **through the proxy**, with deploy order inverted (Tokenomics proxy → Dispenser impl+proxy → repoint) since `tokenomics` is a constructor immutable.

**No behavior change** to claim/nominee/withheld logic in this PR — bug fixes (vuln-list #8, #9, #12, #25) land as the follow-up PR on top of this base; the L2 `migrate()` fix (#10) and deploy scripts + fork tests follow separately.

**Verified:** forge Dispenser 3/3 + DispenserProxy 9/9 + Depository/Treasury green; full hardhat run green (exit 0); eslint/solhint clean on changed files. CI's `--mc Dispenser` filter picks up the new proxy suite automatically.