### PR TITLE
fix(TargetDispenserL2): surface withheldAmount in migrate() event (#10)

### DIFF
--- a/contracts/staking/DefaultTargetDispenserL2.sol
+++ b/contracts/staking/DefaultTargetDispenserL2.sol
@@ -57,7 +57,8 @@ abstract contract DefaultTargetDispenserL2 is IBridgeErrors {
     event Drain(address indexed owner, uint256 amount);
     event TargetDispenserPaused();
     event TargetDispenserUnpaused();
-    event Migrated(address indexed sender, address indexed newL2TargetDispenser, uint256 amount);
+    event Migrated(address indexed sender, address indexed newL2TargetDispenser, uint256 amount,
+        uint256 withheldAmount);
     event LeftoversRefunded(address indexed sender, uint256 leftovers);
 
     // receiveMessage selector (Ethereum chain)
@@ -516,6 +517,11 @@ abstract contract DefaultTargetDispenserL2 is IBridgeErrors {
     ///         No further write interaction with the contract is going to be possible.
     ///         If the withheld amount is nonzero, it is regulated by the DAO directly on the L1 side.
     ///         If there are outstanding queued requests, they are processed by the DAO directly on the L2 side.
+    ///         The migrated OLAS balance AND the current withheldAmount are both emitted in the Migrated event:
+    ///         the new L2 target dispenser deploys with withheldAmount == 0, so the DAO must restore it via
+    ///         updateWithheldAmountMaintenance(withheldAmount) on the new contract right after migration, or the
+    ///         inflation information (OLAS already minted and held on L2) is lost. Emitting it here makes the
+    ///         exact value to restore part of the migration record rather than off-chain tribal knowledge.
     function migrate(address newL2TargetDispenser) external {
         // Reentrancy guard
         if (_locked > 1) {
@@ -556,7 +562,9 @@ abstract contract DefaultTargetDispenserL2 is IBridgeErrors {
         // Zero the owner
         owner = address(0);
 
-        emit Migrated(msg.sender, newL2TargetDispenser, amount);
+        // Emit the withheld amount alongside the migrated OLAS balance: it is the exact value the DAO must
+        // restore on the new dispenser via updateWithheldAmountMaintenance(), so it must be in the record
+        emit Migrated(msg.sender, newL2TargetDispenser, amount, withheldAmount);
 
         // _locked is now set to 2 for good
     }

--- a/contracts/staking/DefaultTargetDispenserL2.sol
+++ b/contracts/staking/DefaultTargetDispenserL2.sol
@@ -57,6 +57,10 @@ abstract contract DefaultTargetDispenserL2 is IBridgeErrors {
     event Drain(address indexed owner, uint256 amount);
     event TargetDispenserPaused();
     event TargetDispenserUnpaused();
+    /// @dev Emitted on migrate(). NOTE: this 4-arg form changed the event signature/topic0 from the previous
+    ///      Migrated(address,address,uint256). During the L2 cutover both forms coexist on-chain (already-deployed
+    ///      dispensers emit the 3-arg form, new ones this 4-arg form), so any indexer, subgraph or monitor keyed on
+    ///      the old topic0 must handle both.
     event Migrated(address indexed sender, address indexed newL2TargetDispenser, uint256 amount,
         uint256 withheldAmount);
     event LeftoversRefunded(address indexed sender, uint256 leftovers);
@@ -522,6 +526,12 @@ abstract contract DefaultTargetDispenserL2 is IBridgeErrors {
     ///         updateWithheldAmountMaintenance(withheldAmount) on the new contract right after migration, or the
     ///         inflation information (OLAS already minted and held on L2) is lost. Emitting it here makes the
     ///         exact value to restore part of the migration record rather than off-chain tribal knowledge.
+    ///         The value to restore is the emitted withheldAmount, NOT the migrated balance (they differ when
+    ///         residual OLAS sits on the contract). No expectedWithheldAmount parameter is taken: pause / migrate /
+    ///         updateWithheldAmountMaintenance ship as one atomic DAO L1->L2 proposal that already passes the
+    ///         emitted value, and the operator would read any "expected" value from this same storage — so a
+    ///         confirmation argument would add ceremony without safety. Post-migration the old getter still
+    ///         returns withheldAmount; the event is an indexable record, not the recovery mechanism.
     function migrate(address newL2TargetDispenser) external {
         // Reentrancy guard
         if (_locked > 1) {

--- a/test/StakingBridging.js
+++ b/test/StakingBridging.js
@@ -610,14 +610,23 @@ describe("StakingBridging", async () => {
             // Initial withheld amount is zero
             expect(await olas.balanceOf(newArbitrumTargetDispenserL2.address)).to.equal(0);
 
-            // Migrate the contract to a new one
-            await arbitrumTargetDispenserL2.migrate(newArbitrumTargetDispenserL2.address);
+            // The current withheld amount to be carried across the migration (vuln-list #10)
+            const withheldToCarry = await arbitrumTargetDispenserL2.withheldAmount();
+            expect(withheldToCarry).to.equal(defaultAmount);
+
+            // Migrate the contract to a new one: the Migrated event must surface both the OLAS balance and the
+            // withheld amount the DAO needs to restore on the new dispenser, so it is part of the on-chain record
+            await expect(arbitrumTargetDispenserL2.migrate(newArbitrumTargetDispenserL2.address))
+                .to.emit(arbitrumTargetDispenserL2, "Migrated")
+                .withArgs(deployer.address, newArbitrumTargetDispenserL2.address, defaultAmount, withheldToCarry);
 
             // Update withheldAmount by the DAO
             const withheldAmount = await olas.balanceOf(newArbitrumTargetDispenserL2.address);
             await newArbitrumTargetDispenserL2.updateWithheldAmountMaintenance(withheldAmount);
 
             expect(await olas.balanceOf(newArbitrumTargetDispenserL2.address)).to.equal(withheldAmount);
+            // The restored value matches what the Migrated event reported
+            expect(await newArbitrumTargetDispenserL2.withheldAmount()).to.equal(withheldToCarry);
         });
     });
 

--- a/test/StakingBridging.js
+++ b/test/StakingBridging.js
@@ -594,11 +594,15 @@ describe("StakingBridging", async () => {
             // Pause the deposit processor
             await arbitrumTargetDispenserL2.pause();
 
-            // Deposit some OLAS to the contract
-            await olas.mint(arbitrumTargetDispenserL2.address, defaultAmount);
+            // Deposit OLAS to the contract. Deliberately make the physical balance EXCEED the accounting
+            // withheld amount (as a residual would), so migration carries a balance != withheld. This is what
+            // lets the test prove the restore uses the emitted withheld value rather than the migrated balance.
+            const balanceToMigrate = defaultAmount + 50;
+            const withheldToRestore = defaultAmount;
+            await olas.mint(arbitrumTargetDispenserL2.address, balanceToMigrate);
 
-            // Update withheldAmount by the DAO
-            await arbitrumTargetDispenserL2.updateWithheldAmountMaintenance(defaultAmount);
+            // Update withheldAmount by the DAO (strictly below the physical balance)
+            await arbitrumTargetDispenserL2.updateWithheldAmountMaintenance(withheldToRestore);
 
             // Deploy another contract
             const ArbitrumTargetDispenserL2 = await ethers.getContractFactory("ArbitrumTargetDispenserL2");
@@ -612,21 +616,24 @@ describe("StakingBridging", async () => {
 
             // The current withheld amount to be carried across the migration (vuln-list #10)
             const withheldToCarry = await arbitrumTargetDispenserL2.withheldAmount();
-            expect(withheldToCarry).to.equal(defaultAmount);
+            expect(withheldToCarry).to.equal(withheldToRestore);
 
-            // Migrate the contract to a new one: the Migrated event must surface both the OLAS balance and the
-            // withheld amount the DAO needs to restore on the new dispenser, so it is part of the on-chain record
+            // Migrate: the Migrated event surfaces BOTH the full OLAS balance and the withheld amount to restore.
+            // These differ here, so the withheld arg genuinely reflects storage, not the transferred balance.
             await expect(arbitrumTargetDispenserL2.migrate(newArbitrumTargetDispenserL2.address))
                 .to.emit(arbitrumTargetDispenserL2, "Migrated")
-                .withArgs(deployer.address, newArbitrumTargetDispenserL2.address, defaultAmount, withheldToCarry);
+                .withArgs(deployer.address, newArbitrumTargetDispenserL2.address, balanceToMigrate, withheldToCarry);
 
-            // Update withheldAmount by the DAO
-            const withheldAmount = await olas.balanceOf(newArbitrumTargetDispenserL2.address);
-            await newArbitrumTargetDispenserL2.updateWithheldAmountMaintenance(withheldAmount);
+            // The full balance migrated across
+            expect(await olas.balanceOf(newArbitrumTargetDispenserL2.address)).to.equal(balanceToMigrate);
 
-            expect(await olas.balanceOf(newArbitrumTargetDispenserL2.address)).to.equal(withheldAmount);
-            // The restored value matches what the Migrated event reported
+            // The DAO restores from the EMITTED withheld amount (not the migrated balance)
+            await newArbitrumTargetDispenserL2.updateWithheldAmountMaintenance(withheldToCarry);
+
+            // The restored value is the emitted withheld amount, strictly less than the migrated balance —
+            // which is exactly what proves the balance was not used as the restore source
             expect(await newArbitrumTargetDispenserL2.withheldAmount()).to.equal(withheldToCarry);
+            expect(await newArbitrumTargetDispenserL2.withheldAmount()).to.not.equal(balanceToMigrate);
         });
     });
 


### PR DESCRIPTION
PR-C of the Dispenser rework, **stacked on #310** (base: `fix/dispenser-vuln-fixes`). Closes `Vulnerabilities_list_tokenomics.md` **#10** in `DefaultTargetDispenserL2`.

**Problem.** `migrate(newL2TargetDispenser)` transfers the full OLAS balance to the new L2 dispenser and permanently bricks the old one, but the new dispenser deploys with `withheldAmount == 0` and there's no L1-side setter — the DAO must restore it via `updateWithheldAmountMaintenance()` right after. The `Migrated` event previously carried only the OLAS balance, so the exact value to restore was off-chain knowledge and could be silently dropped (losing the inflation information for OLAS already minted and held on L2).

**Fix.** The `Migrated` event now includes `withheldAmount`, making the value-to-restore part of the on-chain migration record. Nothing else changes (OLAS balance still moves, owner still zeroed, contract still locks for good). It's a base-contract change inherited by all chain variants (Arbitrum / Gnosis / Optimism / Polygon `TargetDispenserL2`).

**Tests.** `test/StakingBridging.js` withheld-recovery migrate test now asserts the `Migrated` event carries `(sender, newDispenser, amount, withheldAmount)` and that the DAO's restored value on the new dispenser matches the emitted one. Suite green: **21 passing**. `yarn compile` clean; solhint unaffected.

Separate PR per the plan because this is a different contract family (staking stack) with its own suite. After this, the remaining item is **PR-D** (forge deploy scripts for the Dispenser impl + `DispenserProxy`, and L1 mainnet-fork tests of the proxied claim path).