### PR TITLE
test(Dispenser): deploy scripts + L1 mainnet-fork claim test (PR-D)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ forge test -f $FORK_ETH_NODE_URL --mc LiquidityManagerETH -vvv       # ETH mainn
 forge test -f $FORK_ETH_NODE_URL --mc LiquidityManagerObservationCardinalityGasETH -vvv
 forge test -f $FORK_ETH_NODE_URL --mc UniswapPriceOracleETH -vvv
 forge test -f $FORK_ETH_NODE_URL --mc BuyBackBurnerUniswapETH -vvv
+forge test -f $FORK_ETH_NODE_URL --mc StakingClaimForkETH -vvv        # proxied Dispenser claim path vs live Tokenomics/Treasury
 forge test -f $FORK_BASE_NODE_URL --mc LiquidityManagerBase -vvv      # Base
 forge test -f $FORK_BASE_NODE_URL --mc BalancerPriceOracleBase -vvv
 forge test -f $FORK_BASE_NODE_URL --mc BuyBackBurnerBalancerBase -vvv

--- a/scripts/deployment/deploy_07a_dispenser.sh
+++ b/scripts/deployment/deploy_07a_dispenser.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+# Deploys the Dispenser implementation (proxy-based Dispenser). The constructor sets the
+# implementation-bytecode immutables only; the mutable state is set by initialize(), which is
+# delegatecall-ed by the DispenserProxy constructor in deploy_07b_dispenser_proxy.sh.
+#
+# WARNING: the constructor immutables are safety-critical — a wrong value silently rewires the proxy.
+# Double-check tokenomicsProxyAddress (NOT the tokenomics implementation) and retainerAddress.
+#
+# Globals fields consumed:
+#   olasAddress            : OLAS token address
+#   tokenomicsProxyAddress : Tokenomics PROXY address (implementation immutable)
+#   retainerAddress        : retainer in bytes32 form
+#   minStakingWeight       : default min staking weight (bounded by uint16)
+#   maxStakingIncentive    : default max staking incentive (bounded by uint96)
+# Globals fields written:
+#   dispenserAddress       : deployed Dispenser implementation address (consumed by deploy_07b_*)
+
+red=$(tput setaf 1)
+green=$(tput setaf 2)
+reset=$(tput sgr0)
+
+# Get globals file
+globals="$(dirname "$0")/globals_$1.json"
+if [ ! -f $globals ]; then
+  echo "${red}!!! $globals is not found${reset}"
+  exit 0
+fi
+
+# Read variables using jq
+contractVerification=$(jq -r '.contractVerification' $globals)
+useLedger=$(jq -r '.useLedger' $globals)
+derivationPath=$(jq -r '.derivationPath' $globals)
+chainId=$(jq -r '.chainId' $globals)
+networkURL=$(jq -r '.networkURL' $globals)
+
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
+  fi
+fi
+
+olasAddress=$(jq -r '.olasAddress' $globals)
+tokenomicsProxyAddress=$(jq -r '.tokenomicsProxyAddress' $globals)
+retainerAddress=$(jq -r '.retainerAddress' $globals)
+minStakingWeight=$(jq -r '.minStakingWeight' $globals)
+maxStakingIncentive=$(jq -r '.maxStakingIncentive' $globals)
+
+if [ -z "$tokenomicsProxyAddress" ] || [ "$tokenomicsProxyAddress" == "null" ] \
+   || [ "$tokenomicsProxyAddress" == "0x0000000000000000000000000000000000000000" ]; then
+  echo "${red}!!! tokenomicsProxyAddress is not set in $globals${reset}"
+  exit 1
+fi
+
+contractName="Dispenser"
+contractPath="contracts/$contractName.sol:$contractName"
+constructorArgs="$olasAddress $tokenomicsProxyAddress $retainerAddress $minStakingWeight $maxStakingIncentive"
+contractArgs="$contractPath --constructor-args $constructorArgs"
+
+# Get deployer based on the ledger flag
+if [ "$useLedger" == "true" ]; then
+  walletArgs="-l --mnemonic-derivation-path $derivationPath"
+  deployer=$(cast wallet address $walletArgs)
+else
+  echo "Using PRIVATE_KEY: ${PRIVATE_KEY:0:6}..."
+  walletArgs="--private-key $PRIVATE_KEY"
+  deployer=$(cast wallet address $walletArgs)
+fi
+
+# Deployment message
+echo "${green}Deploying from: $deployer${reset}"
+echo "RPC: $networkURL"
+echo "${green}Deployment of: $contractArgs${reset}"
+
+# Deploy the contract and capture the address
+execCmd="forge create --broadcast --rpc-url $networkURL$API_KEY $walletArgs $contractArgs"
+deploymentOutput=$($execCmd)
+dispenserAddress=$(echo "$deploymentOutput" | grep 'Deployed to:' | awk '{print $3}')
+
+# Get output length
+outputLength=${#dispenserAddress}
+
+# Check for the deployed address
+if [ $outputLength != 42 ]; then
+  echo "${red}!!! The contract was not deployed...${reset}"
+  exit 0
+fi
+
+# Write new deployed contract back into JSON
+echo "$(jq '. += {"dispenserAddress":"'$dispenserAddress'"}' $globals)" > $globals
+
+# Verify contract
+if [ "$contractVerification" == "true" ]; then
+  contractParams="$dispenserAddress $contractPath --constructor-args $(cast abi-encode "constructor(address,address,bytes32,uint256,uint256)" $constructorArgs)"
+  echo "Verification contract params: $contractParams"
+
+  echo "${green}Verifying contract on Etherscan...${reset}"
+  forge verify-contract --chain-id "$chainId" --etherscan-api-key "$ETHERSCAN_API_KEY" $contractParams
+
+  blockscoutURL=$(jq -r '.blockscoutURL' $globals)
+  if [ "$blockscoutURL" != "null" ]; then
+    echo "${green}Verifying contract on Blockscout...${reset}"
+    forge verify-contract --verifier blockscout --verifier-url "$blockscoutURL/api" $contractParams
+  fi
+fi
+
+echo "${green}$contractName deployed at: $dispenserAddress${reset}"

--- a/scripts/deployment/deploy_07b_dispenser_proxy.sh
+++ b/scripts/deployment/deploy_07b_dispenser_proxy.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+# Deploys DispenserProxy pointing at the Dispenser implementation from deploy_07a_dispenser.sh.
+# The proxy constructor delegatecall-initializes the impl via
+# Dispenser.initialize(address _treasury, address _voteWeighting, uint256 _maxNumClaimingEpochs,
+# uint256 _maxNumStakingTargets); the caller (deployer) becomes the proxy owner atomically, and
+# staking incentives are paused until the DAO wires and unpauses them.
+#
+# Globals fields consumed:
+#   dispenserAddress      : Dispenser implementation (written by deploy_07a_*)
+#   treasuryAddress       : Treasury address
+#   voteWeightingAddress  : Vote Weighting address
+#   maxNumClaimingEpochs  : max number of epochs to claim staking incentives for
+#   maxNumStakingTargets  : max number of staking targets on a single chain Id
+# Globals fields written:
+#   dispenserProxyAddress : deployed proxy address (the live Dispenser address to wire everywhere)
+
+red=$(tput setaf 1)
+green=$(tput setaf 2)
+reset=$(tput sgr0)
+
+# Get globals file
+globals="$(dirname "$0")/globals_$1.json"
+if [ ! -f $globals ]; then
+  echo "${red}!!! $globals is not found${reset}"
+  exit 0
+fi
+
+# Read variables using jq
+contractVerification=$(jq -r '.contractVerification' $globals)
+useLedger=$(jq -r '.useLedger' $globals)
+derivationPath=$(jq -r '.derivationPath' $globals)
+chainId=$(jq -r '.chainId' $globals)
+networkURL=$(jq -r '.networkURL' $globals)
+
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
+  fi
+fi
+
+dispenserAddress=$(jq -r '.dispenserAddress' $globals)
+treasuryAddress=$(jq -r '.treasuryAddress' $globals)
+voteWeightingAddress=$(jq -r '.voteWeightingAddress' $globals)
+maxNumClaimingEpochs=$(jq -r '.maxNumClaimingEpochs' $globals)
+maxNumStakingTargets=$(jq -r '.maxNumStakingTargets' $globals)
+
+if [ -z "$dispenserAddress" ] || [ "$dispenserAddress" == "null" ] \
+   || [ "$dispenserAddress" == "0x0000000000000000000000000000000000000000" ]; then
+  echo "${red}!!! dispenserAddress (impl) is not set in $globals${reset}"
+  exit 1
+fi
+
+proxyData=$(cast calldata "initialize(address,address,uint256,uint256)" $treasuryAddress $voteWeightingAddress $maxNumClaimingEpochs $maxNumStakingTargets)
+
+contractName="DispenserProxy"
+contractPath="contracts/proxies/$contractName.sol:$contractName"
+constructorArgs="$dispenserAddress $proxyData"
+contractArgs="$contractPath --constructor-args $constructorArgs"
+
+# Get deployer based on the ledger flag
+if [ "$useLedger" == "true" ]; then
+  walletArgs="-l --mnemonic-derivation-path $derivationPath"
+  deployer=$(cast wallet address $walletArgs)
+else
+  echo "Using PRIVATE_KEY: ${PRIVATE_KEY:0:6}..."
+  walletArgs="--private-key $PRIVATE_KEY"
+  deployer=$(cast wallet address $walletArgs)
+fi
+
+# Deployment message
+echo "${green}Deploying from: $deployer${reset}"
+echo "RPC: $networkURL"
+echo "${green}Deployment of: $contractArgs${reset}"
+
+# Deploy the contract and capture the address
+execCmd="forge create --broadcast --rpc-url $networkURL$API_KEY $walletArgs $contractArgs"
+deploymentOutput=$($execCmd)
+dispenserProxyAddress=$(echo "$deploymentOutput" | grep 'Deployed to:' | awk '{print $3}')
+
+# Get output length
+outputLength=${#dispenserProxyAddress}
+
+# Check for the deployed address
+if [ $outputLength != 42 ]; then
+  echo "${red}!!! The contract was not deployed...${reset}"
+  exit 0
+fi
+
+# Write new deployed contract back into JSON
+echo "$(jq '. += {"dispenserProxyAddress":"'$dispenserProxyAddress'"}' $globals)" > $globals
+
+# Verify contract
+if [ "$contractVerification" == "true" ]; then
+  contractParams="$dispenserProxyAddress $contractPath --constructor-args $(cast abi-encode "constructor(address,bytes)" $constructorArgs)"
+  echo "Verification contract params: $contractParams"
+
+  echo "${green}Verifying contract on Etherscan...${reset}"
+  forge verify-contract --chain-id "$chainId" --etherscan-api-key "$ETHERSCAN_API_KEY" $contractParams
+
+  blockscoutURL=$(jq -r '.blockscoutURL' $globals)
+  if [ "$blockscoutURL" != "null" ]; then
+    echo "${green}Verifying contract on Blockscout...${reset}"
+    forge verify-contract --verifier blockscout --verifier-url "$blockscoutURL/api" $contractParams
+  fi
+fi
+
+echo "${green}$contractName deployed at: $dispenserProxyAddress${reset}"

--- a/scripts/deployment/script_dispenser_change_implementation.sh
+++ b/scripts/deployment/script_dispenser_change_implementation.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Points the live DispenserProxy at a new Dispenser implementation (deployed by deploy_07a_dispenser.sh).
+# Owner-gated: the sender must be the DispenserProxy owner. On mainnet this is a DAO/Timelock action,
+# not an EOA broadcast — use the governance proposal path instead of running this directly.
+#
+# Usage: script_dispenser_change_implementation.sh <network>
+#
+# Globals fields consumed:
+#   dispenserAddress      : new Dispenser implementation to switch to
+#   dispenserProxyAddress : live DispenserProxy address
+
+# Check if $1 is provided
+if [ -z "$1" ]; then
+  echo "Usage: $0 <network>"
+  echo "Example: $0 mainnet"
+  exit 1
+fi
+
+red=$(tput setaf 1)
+green=$(tput setaf 2)
+reset=$(tput sgr0)
+
+# Get globals file
+globals="$(dirname "$0")/globals_$1.json"
+if [ ! -f $globals ]; then
+  echo "${red}!!! $globals is not found${reset}"
+  exit 0
+fi
+
+# Read variables using jq
+useLedger=$(jq -r '.useLedger' $globals)
+derivationPath=$(jq -r '.derivationPath' $globals)
+chainId=$(jq -r '.chainId' $globals)
+networkURL=$(jq -r '.networkURL' $globals)
+
+dispenserAddress=$(jq -r '.dispenserAddress' $globals)
+dispenserProxyAddress=$(jq -r '.dispenserProxyAddress' $globals)
+
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
+  fi
+fi
+
+# Get deployer based on the ledger flag
+if [ "$useLedger" == "true" ]; then
+  walletArgs="-l --mnemonic-derivation-path $derivationPath"
+  deployer=$(cast wallet address $walletArgs)
+else
+  echo "Using PRIVATE_KEY: ${PRIVATE_KEY:0:6}..."
+  walletArgs="--private-key $PRIVATE_KEY"
+  deployer=$(cast wallet address $walletArgs)
+fi
+
+castSendHeader="cast send --rpc-url $networkURL$API_KEY $walletArgs"
+
+echo "${green}Change Dispenser implementation in its proxy${reset}"
+castArgs="$dispenserProxyAddress changeImplementation(address) $dispenserAddress"
+echo $castArgs
+castCmd="$castSendHeader $castArgs"
+result=$($castCmd)
+echo "$result" | grep "status"

--- a/test/StakingClaimForkETH.t.sol
+++ b/test/StakingClaimForkETH.t.sol
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Test} from "forge-std/Test.sol";
+import {Dispenser, Unpaused} from "../contracts/Dispenser.sol";
+import {DispenserProxy} from "../contracts/proxies/DispenserProxy.sol";
+
+/// @dev Ethereum-mainnet fork test of the proxy-based Dispenser claim path against the REAL deployed
+///      Tokenomics proxy and Treasury (not freshly-deployed copies, not mocks).
+///
+///      What the fork uniquely exercises vs the in-test suites:
+///        - the new Dispenser implementation + DispenserProxy plug into the LIVE Tokenomics proxy and
+///          Treasury (real storage: real inflation-curve position, real staking fraction, real owner);
+///        - the migration wiring (owner-gated Treasury/Tokenomics changeManagers repointing the dispenser)
+///          runs against the real Timelock-owned contracts;
+///        - the claim money-path mints REAL OLAS: claim -> Treasury.withdrawToAccount -> OLAS.mint ->
+///          transfer to the deposit processor, with the return/withheld portions refunded to the real
+///          Tokenomics staking inflation.
+///
+///      Vote Weighting (gauge voting is week-boundary / veOLAS-lock bound and infeasible to drive on a fork)
+///      and the L2 deposit processor (pure L1->L2 bridge plumbing) are stand-ins so the weight and the
+///      bridge decimals are deterministic inputs; every OLAS movement and inflation accounting is real.
+///
+///      The contract name intentionally avoids the "Dispenser"/"Treasury"/"Depository" substrings so the
+///      CI `forge test --mc Dispenser` allowlist does not pick it up and run it without a fork.
+///
+///      Run: forge test -f $FORK_ETH_NODE_URL --mc StakingClaimForkETH -vvv
+
+interface ITokenomicsFork {
+    function owner() external view returns (address);
+    function epochLen() external view returns (uint256);
+    function epochCounter() external view returns (uint32);
+    function dispenser() external view returns (address);
+    function checkpoint() external;
+    function changeManagers(address treasury, address depository, address dispenser) external;
+    function mapEpochStakingPoints(uint256 epoch) external view
+        returns (uint96 stakingIncentive, uint96 maxStakingIncentive, uint16 minStakingWeight, uint8 stakingFraction);
+}
+
+interface ITreasuryFork {
+    function dispenser() external view returns (address);
+    function changeManagers(address tokenomics, address depository, address dispenser) external;
+    function paused() external view returns (uint8);
+}
+
+interface IOLASFork {
+    function balanceOf(address account) external view returns (uint256);
+    function totalSupply() external view returns (uint256);
+}
+
+/// @dev Stand-in Vote Weighting: decouples the nominee relative weight from the total weight sum so both the
+///      max-staking-incentive cap and the weight-sum cap can be driven deterministically. Mirrors the real
+///      dispenser coupling (addNominee callback, checkpointNominee, nomineeRelativeWeight).
+contract ForkVoteWeighting {
+    struct Nominee {
+        bytes32 account;
+        uint256 chainId;
+    }
+
+    address public immutable dispenser;
+    mapping(bytes32 => bool) public exists;
+    mapping(bytes32 => uint256) public relativeWeights;
+    mapping(bytes32 => uint256) public weightSums;
+
+    constructor(address _dispenser) {
+        dispenser = _dispenser;
+    }
+
+    function _hash(bytes32 account, uint256 chainId) internal pure returns (bytes32) {
+        return keccak256(abi.encode(Nominee(account, chainId)));
+    }
+
+    function addNominee(address account, uint256 chainId) external {
+        bytes32 nomineeHash = _hash(bytes32(uint256(uint160(account))), chainId);
+        exists[nomineeHash] = true;
+        Dispenser(dispenser).addNominee(nomineeHash);
+    }
+
+    function setWeights(address account, uint256 chainId, uint256 relativeWeight, uint256 weightSum) external {
+        bytes32 nomineeHash = _hash(bytes32(uint256(uint160(account))), chainId);
+        relativeWeights[nomineeHash] = relativeWeight;
+        weightSums[nomineeHash] = weightSum;
+    }
+
+    function checkpointNominee(bytes32 account, uint256 chainId) external view {
+        if (!exists[_hash(account, chainId)]) {
+            revert();
+        }
+    }
+
+    function nomineeRelativeWeight(bytes32 account, uint256 chainId, uint256) external view returns (uint256, uint256) {
+        bytes32 nomineeHash = _hash(account, chainId);
+        return (relativeWeights[nomineeHash], weightSums[nomineeHash]);
+    }
+}
+
+/// @dev Minimal L1 deposit processor: captures what the dispenser forwards to the bridge.
+contract ForkDepositProcessor {
+    uint256 public lastStakingIncentive;
+    uint256 public lastTransferAmount;
+
+    function getBridgingDecimals() external pure returns (uint256) {
+        return 18;
+    }
+
+    function sendMessage(address, uint256 stakingIncentive, bytes memory, uint256 transferAmount) external payable {
+        lastStakingIncentive = stakingIncentive;
+        lastTransferAmount = transferAmount;
+    }
+
+    function updateHashMaintenance(bytes32) external {}
+}
+
+contract StakingClaimForkETH is Test {
+    // Ethereum mainnet addresses
+    address internal constant OLAS = 0x0001A500A6B18995B03f44bb040A5fFc28E45CB0;
+    address internal constant TOKENOMICS = 0xc096362fa6f4A4B1a9ea68b1043416f3381ce300;
+    address internal constant TREASURY = 0xa0DA53447C0f6C4987964d8463da7e6628B30f82;
+    address internal constant TIMELOCK = 0x3C1fF68f5aa342D296d4DEe4Bb1cACCA912D95fE;
+
+    // Dispenser implementation immutables (mainnet defaults)
+    bytes32 internal constant RETAINER = bytes32(uint256(0xdEaD));
+    uint256 internal constant DEFAULT_MIN_STAKING_WEIGHT = 50;
+    uint256 internal constant DEFAULT_MAX_STAKING_INCENTIVE = 60_000 ether;
+
+    // A non-L1 EVM chain Id for the staking target (must differ from block.chainid == 1)
+    uint256 internal constant CHAIN_ID = 100;
+    address internal constant STAKING_TARGET = address(0x57A6);
+
+    Dispenser internal dispenser;
+    ForkVoteWeighting internal vw;
+    ForkDepositProcessor internal depositProcessor;
+    uint256 internal epochLen;
+
+    function setUp() public {
+        epochLen = ITokenomicsFork(TOKENOMICS).epochLen();
+
+        // Deploy the new Dispenser implementation against the LIVE Tokenomics proxy, then the proxy.
+        // Vote Weighting is a placeholder here (set after the proxy exists, under the initial pause).
+        Dispenser dispenserImpl =
+            new Dispenser(OLAS, TOKENOMICS, RETAINER, DEFAULT_MIN_STAKING_WEIGHT, DEFAULT_MAX_STAKING_INCENTIVE);
+        bytes memory initData = abi.encodeWithSelector(dispenserImpl.initialize.selector,
+            TREASURY, address(this), uint256(1), uint256(10));
+        DispenserProxy dispenserProxy = new DispenserProxy(address(dispenserImpl), initData);
+        dispenser = Dispenser(address(dispenserProxy));
+
+        // Stand-in Vote Weighting over the live proxy; swap it in while staking incentives are paused (#8 guard)
+        vw = new ForkVoteWeighting(address(dispenser));
+        dispenser.changeManagers(address(0), address(vw));
+
+        // Deposit processor for the L2 chain Id
+        depositProcessor = new ForkDepositProcessor();
+        address[] memory processors = new address[](1);
+        processors[0] = address(depositProcessor);
+        uint256[] memory chainIds = new uint256[](1);
+        chainIds[0] = CHAIN_ID;
+        dispenser.setDepositProcessorChainIds(processors, chainIds);
+
+        // Migration wiring: repoint the LIVE Treasury and Tokenomics at the new dispenser (Timelock-owned)
+        vm.startPrank(TIMELOCK);
+        ITreasuryFork(TREASURY).changeManagers(address(0), address(0), address(dispenser));
+        ITokenomicsFork(TOKENOMICS).changeManagers(address(0), address(0), address(dispenser));
+        vm.stopPrank();
+
+        // Go live and register a fresh nominee (records the claim cursor at the current epoch)
+        dispenser.setPauseState(Dispenser.Pause.Unpaused);
+        vw.addNominee(STAKING_TARGET, CHAIN_ID);
+    }
+
+    function _targetBytes32() internal pure returns (bytes32) {
+        return bytes32(uint256(uint160(STAKING_TARGET)));
+    }
+
+    function _stakingIncentiveOf(uint256 epoch) internal view returns (uint256 amount) {
+        (amount, , , ) = ITokenomicsFork(TOKENOMICS).mapEpochStakingPoints(epoch);
+    }
+
+    function _maxStakingIncentiveOf(uint256 epoch) internal view returns (uint256 amount) {
+        (, amount, , ) = ITokenomicsFork(TOKENOMICS).mapEpochStakingPoints(epoch);
+    }
+
+    /// @dev Settles the current epoch on the live Tokenomics so it carries a staking incentive to claim.
+    function _advanceEpoch() internal {
+        vm.warp(block.timestamp + epochLen + 10);
+        vm.roll(block.number + 1);
+        ITokenomicsFork(TOKENOMICS).checkpoint();
+    }
+
+    /// @dev Full weight so the allocation binds on the epoch's max-staking-incentive cap; the weight sum is set
+    ///      large enough not to cap the available amount below the epoch incentive.
+    function _giveFullWeight() internal {
+        vw.setWeights(STAKING_TARGET, CHAIN_ID, 1e18, 1e30);
+    }
+
+    // -----------------------------------------------------------------------
+    // Migration wiring + proxy reads against the real contracts
+    // -----------------------------------------------------------------------
+
+    function test_migrationWiring_realContractsRepointed() public {
+        // Proxy reads resolve against the live Tokenomics/Treasury
+        assertEq(dispenser.tokenomics(), TOKENOMICS, "tokenomics immutable");
+        assertEq(dispenser.treasury(), TREASURY, "treasury set at initialize");
+        assertEq(dispenser.owner(), address(this), "deployer owns the proxy");
+
+        // The live contracts now route to the new dispenser
+        assertEq(ITreasuryFork(TREASURY).dispenser(), address(dispenser), "treasury repointed");
+        assertEq(ITokenomicsFork(TOKENOMICS).dispenser(), address(dispenser), "tokenomics repointed");
+
+        // changeImplementation stays owner-gated on the live proxy
+        vm.prank(address(0xBAD));
+        vm.expectRevert();
+        dispenser.changeImplementation(address(0x1234));
+    }
+
+    // -----------------------------------------------------------------------
+    // Claim money-path: real Treasury mint + real Tokenomics refund
+    // -----------------------------------------------------------------------
+
+    function test_proxiedClaim_realTreasuryMint_realInflationRefund() public {
+        _giveFullWeight();
+        _advanceEpoch();
+
+        uint256 claimableEpoch = ITokenomicsFork(TOKENOMICS).epochCounter() - 1;
+        uint256 epochIncentive = _stakingIncentiveOf(claimableEpoch);
+        uint256 maxInc = _maxStakingIncentiveOf(claimableEpoch);
+        assertGt(epochIncentive, 0, "settled epoch must carry a staking incentive");
+
+        // At current mainnet inflation a full epoch incentive exceeds the per-epoch cap, so the cap binds
+        uint256 expectedStaking = epochIncentive < maxInc ? epochIncentive : maxInc;
+        uint256 expectedReturn = epochIncentive - expectedStaking;
+
+        uint256 currentEpoch = ITokenomicsFork(TOKENOMICS).epochCounter();
+        uint256 potBefore = _stakingIncentiveOf(currentEpoch);
+        uint256 supplyBefore = IOLASFork(OLAS).totalSupply();
+
+        dispenser.claimStakingIncentives(1, CHAIN_ID, _targetBytes32(), "");
+
+        // Real OLAS was minted by the live Treasury and forwarded to the deposit processor
+        assertEq(IOLASFork(OLAS).balanceOf(address(depositProcessor)), expectedStaking, "OLAS delivered to processor");
+        assertEq(depositProcessor.lastStakingIncentive(), expectedStaking, "incentive communicated to L2");
+        assertEq(depositProcessor.lastTransferAmount(), expectedStaking, "no withheld: transfer == incentive");
+        assertEq(IOLASFork(OLAS).totalSupply() - supplyBefore, expectedStaking, "totalSupply grew by the mint");
+
+        // The capped-off remainder is refunded to the live staking inflation of the current epoch
+        uint256 potAfter = _stakingIncentiveOf(currentEpoch);
+        assertEq(potAfter - potBefore, expectedReturn, "capped remainder refunded to inflation");
+    }
+
+    function test_proxiedClaim_withheldNetting_refundsReusedInflation() public {
+        _giveFullWeight();
+
+        // Seed a withheld amount (as the DAO would after an undelivered L2 batch) below the capped incentive
+        uint256 withheld = 10_000 ether;
+        dispenser.syncWithheldAmountMaintenance(CHAIN_ID, withheld, bytes32(uint256(1)));
+        assertEq(dispenser.mapChainIdWithheldAmounts(CHAIN_ID), withheld, "withheld seeded");
+
+        _advanceEpoch();
+
+        uint256 claimableEpoch = ITokenomicsFork(TOKENOMICS).epochCounter() - 1;
+        uint256 epochIncentive = _stakingIncentiveOf(claimableEpoch);
+        uint256 maxInc = _maxStakingIncentiveOf(claimableEpoch);
+        uint256 expectedStaking = epochIncentive < maxInc ? epochIncentive : maxInc;
+        assertGt(expectedStaking, withheld, "withheld must be below the incentive to exercise both branches");
+        uint256 standardReturn = epochIncentive - expectedStaking;
+
+        uint256 currentEpoch = ITokenomicsFork(TOKENOMICS).epochCounter();
+        uint256 potBefore = _stakingIncentiveOf(currentEpoch);
+        uint256 supplyBefore = IOLASFork(OLAS).totalSupply();
+
+        dispenser.claimStakingIncentives(1, CHAIN_ID, _targetBytes32(), "");
+
+        // Withheld fully consumed; only the non-covered part is actually minted and transferred
+        assertEq(dispenser.mapChainIdWithheldAmounts(CHAIN_ID), 0, "withheld consumed");
+        assertEq(depositProcessor.lastStakingIncentive(), expectedStaking, "full incentive communicated to L2");
+        assertEq(depositProcessor.lastTransferAmount(), expectedStaking - withheld, "transfer netted by withheld");
+        assertEq(IOLASFork(OLAS).totalSupply() - supplyBefore, expectedStaking - withheld, "only netted OLAS minted");
+
+        // Standard return plus the withheld-covered portion are both returned to the live staking inflation
+        uint256 potAfter = _stakingIncentiveOf(currentEpoch);
+        assertEq(potAfter - potBefore, standardReturn + withheld, "standard return + reused withheld refunded");
+    }
+}


### PR DESCRIPTION
PR-D of the Dispenser-rework series (stacked on #311). **Deploy machinery + a real-contract fork test** — the release condition the auditor held the on-chain deploy on. No contract changes; the audited code from #309/#310/#311 is untouched.

### Deploy scripts (forge `.sh`)
- `deploy_07a_dispenser.sh` — Dispenser implementation (the 5 bytecode immutables; warns that a wrong immutable silently rewires the proxy).
- `deploy_07b_dispenser_proxy.sh` — `DispenserProxy` with `initialize()` calldata (deployer becomes owner, staking incentives paused until wired).
- `script_dispenser_change_implementation.sh` — owner-gated `changeImplementation` upgrade helper.

The deploy-order inversion (Tokenomics proxy → Dispenser impl+proxy → repoint) and the greenfield-only storage-image invariant are documented inline in the scripts.

### L1 mainnet-fork test — `test/StakingClaimForkETH.t.sol`
Runs against the **live** deployed Tokenomics proxy and Treasury (real storage: real inflation-curve position, 75% staking fraction, real Timelock owner), not fresh copies or mocks:
- **`test_migrationWiring_realContractsRepointed`** — deploys the new impl+proxy, repoints the real Timelock-owned Treasury/Tokenomics at it, asserts the wiring + owner-gated `changeImplementation`.
- **`test_proxiedClaim_realTreasuryMint_realInflationRefund`** — the money-path: `claim → Treasury.withdrawToAccount → real OLAS mint (60k OLAS) → deposit processor`, capped remainder refunded to live staking inflation.
- **`test_proxiedClaim_withheldNetting_refundsReusedInflation`** — withheld netting over real Tokenomics: transfer netted by withheld, reused-withheld portion refunded to inflation (#9 path on real contracts).

Vote Weighting (gauge voting is week-boundary/veOLAS-lock bound, infeasible to drive on a fork) and the L2 deposit processor (bridge plumbing) are deterministic stand-ins; every OLAS movement and inflation accounting is real.

Run: `forge test -f $FORK_ETH_NODE_URL --mc StakingClaimForkETH -vvv` — **3/3 pass**.

### CI safety
The fork-test contract name avoids the `Dispenser`/`Treasury`/`Depository` substrings, so the fork-less CI `forge test --mc Dispenser` allowlist does **not** pick it up (verified). Unit suites unchanged: `--mc Dispenser` 17/17.

### Out of scope (by design)
No `Vulnerabilities_list_tokenomics.md` edit — those entries come off only after the physical redeploy + rewiring closes the exposure on-chain, not when a fix branch merges. No CHANGELOG edit (tag-scoped).