### PR TITLE
refactor(Dispenser): drop default staking-param fallback + obsolete changeStakingParams

### DIFF
--- a/contracts/Dispenser.sol
+++ b/contracts/Dispenser.sol
@@ -369,8 +369,11 @@ contract Dispenser {
             revert AlreadyInitialized();
         }
 
-        // Check for at least one zero contract address
-        if (_treasury == address(0) || _voteWeighting == address(0)) {
+        // Check for a zero Treasury address. The Vote Weighting address is intentionally allowed to be zero
+        // here: on a fresh proxy deploy the Vote Weighting contract does not exist yet (it is deployed with
+        // this proxy's address baked in as an immutable), so it is wired in afterwards via changeManagers()
+        // while staking incentives stay paused. No claim path can run with a zero Vote Weighting.
+        if (_treasury == address(0)) {
             revert ZeroAddress();
         }
 

--- a/contracts/Dispenser.sol
+++ b/contracts/Dispenser.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.25;
+pragma solidity ^0.8.30;
 
 // Deposit Processor interface
 interface IDepositProcessor {
@@ -272,7 +272,6 @@ contract Dispenser {
     event ImplementationUpdated(address indexed implementation);
     event TreasuryUpdated(address indexed treasury);
     event VoteWeightingUpdated(address indexed voteWeighting);
-    event StakingParamsUpdated(uint256 maxNumClaimingEpochs, uint256 maxNumStakingTargets);
     event IncentivesClaimed(address indexed owner, uint256 reward, uint256 topUp, uint256[] unitTypes, uint256[] unitIds);
     event StakingIncentivesClaimed(address indexed account, uint256 chainId, bytes32 stakingTarget,
         uint256 stakingIncentive, uint256 transferAmount, uint256 returnAmount);
@@ -292,14 +291,9 @@ contract Dispenser {
     // Maximum chain Id as per EVM specs
     uint256 public constant MAX_EVM_CHAIN_ID = type(uint64).max / 2 - 36;
 
-    // Immutables live in the implementation bytecode, not proxy storage: they are re-settable by deploying
-    // a new implementation and calling changeImplementation. Every new implementation deploy must pass the
-    // correct constructor args — a wrong value silently rewires the proxy.
-    uint256 public immutable defaultMinStakingWeight;
-    uint256 public immutable defaultMaxStakingIncentive;
     // OLAS token address
     address public immutable olas;
-    // Tokenomics proxy address (stable by construction — the proxy address never changes)
+    // Tokenomics proxy address
     address public immutable tokenomics;
     // Retainer address in bytes32 form
     bytes32 public immutable retainer;
@@ -341,31 +335,14 @@ contract Dispenser {
     /// @param _olas OLAS token address.
     /// @param _tokenomics Tokenomics proxy address.
     /// @param _retainer Retainer address in bytes32 form.
-    /// @param _defaultMinStakingWeight Default min staking weight (bounded by uint16).
-    /// @param _defaultMaxStakingIncentive Default max staking incentive (bounded by uint96).
     constructor(
         address _olas,
         address _tokenomics,
-        bytes32 _retainer,
-        uint256 _defaultMinStakingWeight,
-        uint256 _defaultMaxStakingIncentive
+        bytes32 _retainer
     ) {
         // Check for at least one zero contract address
         if (_olas == address(0) || _tokenomics == address(0) || _retainer == 0) {
             revert ZeroAddress();
-        }
-
-        // Check for zero value staking parameters
-        if (_defaultMinStakingWeight == 0 || _defaultMaxStakingIncentive == 0) {
-            revert ZeroValue();
-        }
-
-        // Check for maximum values
-        if (_defaultMinStakingWeight > type(uint16).max) {
-            revert Overflow(_defaultMinStakingWeight, type(uint16).max);
-        }
-        if (_defaultMaxStakingIncentive > type(uint96).max) {
-            revert Overflow(_defaultMaxStakingIncentive, type(uint96).max);
         }
 
         olas = _olas;
@@ -373,8 +350,6 @@ contract Dispenser {
 
         retainer = _retainer;
         retainerHash = keccak256(abi.encode(IVoteWeighting.Nominee(retainer, block.chainid)));
-        defaultMinStakingWeight = _defaultMinStakingWeight;
-        defaultMaxStakingIncentive = _defaultMaxStakingIncentive;
     }
 
     /// @dev Initializes the dispenser proxy storage.
@@ -784,26 +759,6 @@ contract Dispenser {
         }
     }
 
-    /// @dev Changes staking params by the DAO.
-    /// @param _maxNumClaimingEpochs Maximum number of epochs to claim staking incentives for.
-    /// @param _maxNumStakingTargets Maximum number of staking targets available to claim for on a single chain Id.
-    function changeStakingParams(uint256 _maxNumClaimingEpochs, uint256 _maxNumStakingTargets) external {
-        // Check for the contract ownership
-        if (msg.sender != owner) {
-            revert OwnerOnly(msg.sender, owner);
-        }
-
-        // Check if values are zero
-        if (_maxNumClaimingEpochs == 0 || _maxNumStakingTargets == 0) {
-            revert ZeroValue();
-        }
-
-        maxNumClaimingEpochs = _maxNumClaimingEpochs;
-        maxNumStakingTargets = _maxNumStakingTargets;
-
-        emit StakingParamsUpdated(_maxNumClaimingEpochs, _maxNumStakingTargets);
-    }
-
     /// @dev Sets deposit processor contracts addresses and L2 chain Ids.
     /// @notice It is the contract owner responsibility to set correct L1 deposit processor contracts
     ///         and corresponding supported L2 chain Ids.
@@ -1020,15 +975,8 @@ contract Dispenser {
             ITokenomics.StakingPoint memory stakingPoint =
                 ITokenomics(tokenomics).mapEpochStakingPoints(j);
 
-            // Check for staking parameters to all make sense
-            if (stakingPoint.stakingFraction > 0) {
-                // Check for unset values
-                if (stakingPoint.minStakingWeight == 0 && stakingPoint.maxStakingIncentive == 0) {
-                    stakingPoint.minStakingWeight = uint16(defaultMinStakingWeight);
-                    stakingPoint.maxStakingIncentive = uint96(defaultMaxStakingIncentive);
-                }
-            } else {
-                // No staking incentives in this epoch
+            // No staking incentives in this epoch
+            if (stakingPoint.stakingFraction == 0) {
                 continue;
             }
 

--- a/contracts/Dispenser.sol
+++ b/contracts/Dispenser.sol
@@ -332,6 +332,11 @@ contract Dispenser {
 
     /// @dev Dispenser implementation constructor: sets the implementation-bytecode immutables only.
     /// @notice The mutable state is set via initialize() delegatecall-ed by the DispenserProxy constructor.
+    /// @notice Immutable vs proxy storage rationale: olas / tokenomics / retainer are fixed identities that never
+    ///         change for a deployment (tokenomics is the stable TokenomicsProxy address), so they live in
+    ///         implementation bytecode. treasury / voteWeighting (repointable managers via changeManagers) and
+    ///         maxNumClaimingEpochs / maxNumStakingTargets (init-time bounds) are proxy storage instead, so they
+    ///         survive an implementation upgrade and can be (re)set without deploying a new implementation.
     /// @param _olas OLAS token address.
     /// @param _tokenomics Tokenomics proxy address.
     /// @param _retainer Retainer address in bytes32 form.
@@ -1363,6 +1368,14 @@ contract Dispenser {
         // Check the contract ownership
         if (msg.sender != owner) {
             revert OwnerOnly(msg.sender, owner);
+        }
+
+        // Do not let staking incentives go live before Vote Weighting is wired. A fresh proxy initializes with a
+        // zero voteWeighting (set later via changeManagers); claims would fail-safe with ZeroValue anyway, but this
+        // makes the deploy invariant explicit rather than emergent.
+        if (pauseState != Pause.StakingIncentivesPaused && pauseState != Pause.AllPaused &&
+            voteWeighting == address(0)) {
+            revert ZeroAddress();
         }
 
         paused = pauseState;

--- a/contracts/proxies/DispenserProxy.sol
+++ b/contracts/proxies/DispenserProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.25;
+pragma solidity ^0.8.30;
 
 /// @dev Proxy initialization failed.
 error InitializationFailed();
@@ -23,6 +23,7 @@ error ZeroValue();
 /// @title DispenserProxy - Smart contract for dispenser proxy
 /// @author Aleksandr Kuperman - <aleksandr.kuperman@valory.xyz>
 /// @author Andrey Lebedev - <andrey.lebedev@valory.xyz>
+/// @author Mariapia Moscatiello - <mariapia.moscatiello@valory.xyz>
 contract DispenserProxy {
     // Code position in storage is keccak256("PROXY_DISPENSER") = "0x8bd249c73459f2c50400ebdc57436101fc7d9a76908baf1ba5be362b47b48f83"
     bytes32 public constant PROXY_DISPENSER = 0x8bd249c73459f2c50400ebdc57436101fc7d9a76908baf1ba5be362b47b48f83;

--- a/scripts/audit_chains/audit_contracts_setup.js
+++ b/scripts/audit_chains/audit_contracts_setup.js
@@ -249,7 +249,7 @@ async function checkTokenomicsProxy(chainId, provider, globalsInstance, configCo
 
     // Check dispenser
     const dispenser = await tokenomics.dispenser();
-    customExpect(dispenser, globalsInstance["dispenserAddress"], log + ", function: dispenser()");
+    customExpect(dispenser, globalsInstance["dispenserProxyAddress"], log + ", function: dispenser()");
 
     // Check tokenomics implementation address.
     // Reads the current `tokenomicsAddress` field, which is the address the DAO will vote in
@@ -290,7 +290,7 @@ async function checkTreasury(chainId, provider, globalsInstance, configContracts
 
     // Check dispenser
     const dispenser = await treasury.dispenser();
-    customExpect(dispenser, globalsInstance["dispenserAddress"], log + ", function: dispenser()");
+    customExpect(dispenser, globalsInstance["dispenserProxyAddress"], log + ", function: dispenser()");
 
     // Check minAcceptedETH (0.065 ETH)
     const minAcceptedETH = await treasury.minAcceptedETH();
@@ -394,7 +394,7 @@ async function checkDepositProcessorL1(depositProcessorL1, globalsInstance, log)
 
     // Check L1 dispenser
     const dispenser = await depositProcessorL1.l1Dispenser();
-    customExpect(dispenser, globalsInstance["dispenserAddress"], log + ", function: dispenser   ()");
+    customExpect(dispenser, globalsInstance["dispenserProxyAddress"], log + ", function: dispenser   ()");
 }
 
 // Check ArbitrumDepositProcessorL1: chain Id, provider, parsed globals, configuration contracts, contract name
@@ -452,7 +452,7 @@ async function checkEthereumDepositProcessor(chainId, provider, globalsInstance,
 
     // Check dispenser
     const dispenser = await ethereumDepositProcessorL1.dispenser();
-    customExpect(dispenser, globalsInstance["dispenserAddress"], log + ", function: dispenser()");
+    customExpect(dispenser, globalsInstance["dispenserProxyAddress"], log + ", function: dispenser()");
 
     // Check L1 staking factory
     const stakingFactory = await ethereumDepositProcessorL1.stakingFactory();

--- a/scripts/deployment/deploy_07a_dispenser.sh
+++ b/scripts/deployment/deploy_07a_dispenser.sh
@@ -11,8 +11,6 @@
 #   olasAddress            : OLAS token address
 #   tokenomicsProxyAddress : Tokenomics PROXY address (implementation immutable)
 #   retainerAddress        : retainer in bytes32 form
-#   minStakingWeight       : default min staking weight (bounded by uint16)
-#   maxStakingIncentive    : default max staking incentive (bounded by uint96)
 # Globals fields written:
 #   dispenserAddress       : deployed Dispenser implementation address (consumed by deploy_07b_*)
 
@@ -49,8 +47,6 @@ fi
 olasAddress=$(jq -r '.olasAddress' $globals)
 tokenomicsProxyAddress=$(jq -r '.tokenomicsProxyAddress' $globals)
 retainerAddress=$(jq -r '.retainerAddress' $globals)
-minStakingWeight=$(jq -r '.minStakingWeight' $globals)
-maxStakingIncentive=$(jq -r '.maxStakingIncentive' $globals)
 
 if [ -z "$tokenomicsProxyAddress" ] || [ "$tokenomicsProxyAddress" == "null" ] \
    || [ "$tokenomicsProxyAddress" == "0x0000000000000000000000000000000000000000" ]; then
@@ -60,7 +56,7 @@ fi
 
 contractName="Dispenser"
 contractPath="contracts/$contractName.sol:$contractName"
-constructorArgs="$olasAddress $tokenomicsProxyAddress $retainerAddress $minStakingWeight $maxStakingIncentive"
+constructorArgs="$olasAddress $tokenomicsProxyAddress $retainerAddress"
 contractArgs="$contractPath --constructor-args $constructorArgs"
 
 # Get deployer based on the ledger flag
@@ -97,7 +93,7 @@ echo "$(jq '. += {"dispenserAddress":"'$dispenserAddress'"}' $globals)" > $globa
 
 # Verify contract
 if [ "$contractVerification" == "true" ]; then
-  contractParams="$dispenserAddress $contractPath --constructor-args $(cast abi-encode "constructor(address,address,bytes32,uint256,uint256)" $constructorArgs)"
+  contractParams="$dispenserAddress $contractPath --constructor-args $(cast abi-encode "constructor(address,address,bytes32)" $constructorArgs)"
   echo "Verification contract params: $contractParams"
 
   echo "${green}Verifying contract on Etherscan...${reset}"

--- a/scripts/deployment/deploy_07a_dispenser.sh
+++ b/scripts/deployment/deploy_07a_dispenser.sh
@@ -100,7 +100,12 @@ zeroAddress="0x0000000000000000000000000000000000000000"
 echo "${green}Locking the implementation (initialize on the impl itself)...${reset}"
 lockResult=$(cast send --rpc-url $networkURL$API_KEY $walletArgs $dispenserAddress \
   "initialize(address,address,uint256,uint256)" $deployer $zeroAddress 1 1)
-echo "$lockResult" | grep -i "status"
+lockStatus=$(echo "$lockResult" | grep -iE '^status' | grep -oiE '1 \(success\)|0 \(failed\)')
+if [ -z "$lockStatus" ] || [[ "$lockStatus" == 0* ]]; then
+  echo "${red}!!! Implementation lock tx did not succeed — impl left unlocked. Harmless (the impl cannot affect the proxy), but investigate.${reset}"
+else
+  echo "${green}Implementation locked (status: $lockStatus)${reset}"
+fi
 
 # Verify contract
 if [ "$contractVerification" == "true" ]; then

--- a/scripts/deployment/deploy_07a_dispenser.sh
+++ b/scripts/deployment/deploy_07a_dispenser.sh
@@ -91,6 +91,17 @@ fi
 # Write new deployed contract back into JSON
 echo "$(jq '. += {"dispenserAddress":"'$dispenserAddress'"}' $globals)" > $globals
 
+# Lock the standalone implementation: claim its (inert) storage owner so nobody else can initialize() it.
+# The implementation is only ever delegatecall-ed by the proxy against the PROXY's storage, so the impl's own
+# storage is never used and these are throwaway values (Vote Weighting is allowed to be zero at initialize).
+# This sets owner != 0 on the impl, making a later initialize() revert AlreadyInitialized. Best-effort (the
+# impl holds no funds and cannot affect the proxy, so an unlocked impl is harmless — this just removes the question).
+zeroAddress="0x0000000000000000000000000000000000000000"
+echo "${green}Locking the implementation (initialize on the impl itself)...${reset}"
+lockResult=$(cast send --rpc-url $networkURL$API_KEY $walletArgs $dispenserAddress \
+  "initialize(address,address,uint256,uint256)" $deployer $zeroAddress 1 1)
+echo "$lockResult" | grep -i "status"
+
 # Verify contract
 if [ "$contractVerification" == "true" ]; then
   contractParams="$dispenserAddress $contractPath --constructor-args $(cast abi-encode "constructor(address,address,bytes32)" $constructorArgs)"

--- a/scripts/deployment/deploy_07b_dispenser_proxy.sh
+++ b/scripts/deployment/deploy_07b_dispenser_proxy.sh
@@ -6,14 +6,22 @@
 # uint256 _maxNumStakingTargets); the caller (deployer) becomes the proxy owner atomically, and
 # staking incentives are paused until the DAO wires and unpauses them.
 #
+# Vote Weighting is initialized to the ZERO address on purpose: it is deployed AFTER this proxy (its
+# `dispenser` immutable binds this proxy's address), so it cannot exist yet at init time. It is wired in
+# afterwards with script_dispenser_change_managers.sh, while the proxy is still paused. This is what breaks
+# the otherwise-circular deploy order (Dispenser <-> Vote Weighting).
+#
+# Deploy order: deploy_07a (impl) -> deploy_07b (proxy, VW = 0) -> deploy Vote Weighting(ve, THIS proxy) ->
+#               script_dispenser_change_managers.sh (sets the real VW) -> set deposit processors -> unpause.
+#
 # Globals fields consumed:
 #   dispenserAddress      : Dispenser implementation (written by deploy_07a_*)
 #   treasuryAddress       : Treasury address
-#   voteWeightingAddress  : Vote Weighting address
 #   maxNumClaimingEpochs  : max number of epochs to claim staking incentives for
 #   maxNumStakingTargets  : max number of staking targets on a single chain Id
 # Globals fields written:
-#   dispenserProxyAddress : deployed proxy address (the live Dispenser address to wire everywhere)
+#   dispenserProxyAddress : deployed proxy address (the live Dispenser address to wire everywhere,
+#                           and the address Vote Weighting must be deployed against)
 
 red=$(tput setaf 1)
 green=$(tput setaf 2)
@@ -47,7 +55,6 @@ fi
 
 dispenserAddress=$(jq -r '.dispenserAddress' $globals)
 treasuryAddress=$(jq -r '.treasuryAddress' $globals)
-voteWeightingAddress=$(jq -r '.voteWeightingAddress' $globals)
 maxNumClaimingEpochs=$(jq -r '.maxNumClaimingEpochs' $globals)
 maxNumStakingTargets=$(jq -r '.maxNumStakingTargets' $globals)
 
@@ -57,6 +64,8 @@ if [ -z "$dispenserAddress" ] || [ "$dispenserAddress" == "null" ] \
   exit 1
 fi
 
+# Vote Weighting is wired later via script_dispenser_change_managers.sh — initialize with the zero address
+voteWeightingAddress="0x0000000000000000000000000000000000000000"
 proxyData=$(cast calldata "initialize(address,address,uint256,uint256)" $treasuryAddress $voteWeightingAddress $maxNumClaimingEpochs $maxNumStakingTargets)
 
 contractName="DispenserProxy"

--- a/scripts/deployment/deploy_07b_dispenser_proxy.sh
+++ b/scripts/deployment/deploy_07b_dispenser_proxy.sh
@@ -64,6 +64,24 @@ if [ -z "$dispenserAddress" ] || [ "$dispenserAddress" == "null" ] \
   exit 1
 fi
 
+if [ -z "$treasuryAddress" ] || [ "$treasuryAddress" == "null" ] \
+   || [ "$treasuryAddress" == "0x0000000000000000000000000000000000000000" ]; then
+  echo "${red}!!! treasuryAddress is not set in $globals${reset}"
+  exit 1
+fi
+
+# maxNumClaimingEpochs / maxNumStakingTargets are set once at initialize() with no runtime setter, so a bad
+# value here is only fixable by an implementation redeploy — validate they are present and non-zero
+if [ -z "$maxNumClaimingEpochs" ] || [ "$maxNumClaimingEpochs" == "null" ] || [ "$maxNumClaimingEpochs" == "0" ]; then
+  echo "${red}!!! maxNumClaimingEpochs is not set (or zero) in $globals${reset}"
+  exit 1
+fi
+
+if [ -z "$maxNumStakingTargets" ] || [ "$maxNumStakingTargets" == "null" ] || [ "$maxNumStakingTargets" == "0" ]; then
+  echo "${red}!!! maxNumStakingTargets is not set (or zero) in $globals${reset}"
+  exit 1
+fi
+
 # Vote Weighting is wired later via script_dispenser_change_managers.sh — initialize with the zero address
 voteWeightingAddress="0x0000000000000000000000000000000000000000"
 proxyData=$(cast calldata "initialize(address,address,uint256,uint256)" $treasuryAddress $voteWeightingAddress $maxNumClaimingEpochs $maxNumStakingTargets)

--- a/scripts/deployment/deploy_08_09_change_managers.js
+++ b/scripts/deployment/deploy_08_09_change_managers.js
@@ -29,14 +29,14 @@ async function main() {
     const tokenomicsProxyAddress = parsedData.tokenomicsProxyAddress;
     const treasuryAddress = parsedData.treasuryAddress;
     const depositoryAddress = parsedData.depositoryAddress;
-    const dispenserAddress = parsedData.dispenserAddress;
+    const dispenserProxyAddress = parsedData.dispenserProxyAddress;
     const AddressZero = "0x" + "0".repeat(40);
 
     // Transaction signing and execution
     console.log("8. EOA to change managers for TokenomicsProxy");
     const tokenomicsProxy = await ethers.getContractAt("Tokenomics", tokenomicsProxyAddress);
     console.log("You are signing the following transaction: TokenomicsProxy.connect(EOA).changeManagers()");
-    let result = await tokenomicsProxy.connect(EOA).changeManagers(treasuryAddress, depositoryAddress, dispenserAddress);
+    let result = await tokenomicsProxy.connect(EOA).changeManagers(treasuryAddress, depositoryAddress, dispenserProxyAddress);
     if (providerName === "sepolia") {
         await new Promise(r => setTimeout(r, 60000));
     }
@@ -48,7 +48,7 @@ async function main() {
     console.log("9. EOA to change managers for Treasury");
     const treasury = await ethers.getContractAt("Treasury", treasuryAddress);
     console.log("You are signing the following transaction: Treasury.connect(EOA).changeManagers()");
-    result = await treasury.connect(EOA).changeManagers(AddressZero, depositoryAddress, dispenserAddress);
+    result = await treasury.connect(EOA).changeManagers(AddressZero, depositoryAddress, dispenserProxyAddress);
     if (providerName === "sepolia") {
         await new Promise(r => setTimeout(r, 60000));
     }

--- a/scripts/deployment/deploy_10_14_change_ownerships.js
+++ b/scripts/deployment/deploy_10_14_change_ownerships.js
@@ -31,7 +31,7 @@ async function main() {
     const tokenomicsProxyAddress = parsedData.tokenomicsProxyAddress;
     const treasuryAddress = parsedData.treasuryAddress;
     const depositoryAddress = parsedData.depositoryAddress;
-    const dispenserAddress = parsedData.dispenserAddress;
+    const dispenserProxyAddress = parsedData.dispenserProxyAddress;
 
     // Transaction signing and execution
     console.log("10. EOA to transfer ownership rights of DonatorBlacklist to Timelock");
@@ -83,14 +83,14 @@ async function main() {
 
     // Transaction signing and execution
     console.log("14. EOA to transfer ownership rights of Dispenser to Timelock");
-    const dispenser = await ethers.getContractAt("Dispenser", dispenserAddress);
+    const dispenser = await ethers.getContractAt("Dispenser", dispenserProxyAddress);
     console.log("You are signing the following transaction: Dispenser.connect(EOA).changeOwner()");
     result = await dispenser.connect(EOA).changeOwner(timelockAddress);
     if (providerName === "sepolia") {
         await new Promise(r => setTimeout(r, 60000));
     }
     // Transaction details
-    console.log("Contract address:", dispenserAddress);
+    console.log("Contract address:", dispenserProxyAddress);
     console.log("Transaction:", result.hash);
 }
 

--- a/scripts/deployment/script_dispenser_change_managers.sh
+++ b/scripts/deployment/script_dispenser_change_managers.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+# Wires the Vote Weighting contract into the live DispenserProxy via changeManagers(address,address).
+#
+# Why this is a separate step: on a fresh deploy the DispenserProxy is initialized with a zero Vote
+# Weighting (the Vote Weighting contract is deployed AFTER the proxy, against the proxy's own address as
+# an immutable). The proxy therefore ships paused; this script sets the real Vote Weighting once it exists.
+# Treasury is passed as the zero address here (it is already set at initialize(), and a zero argument is a
+# no-op in changeManagers) — only Vote Weighting is wired.
+#
+# Ownership note: immediately after deploy the DispenserProxy owner is the deploying EOA, so this runs as a
+# direct cast send. Once ownership is transferred to the DAO Timelock this same call becomes a governance
+# proposal instead — do not run this script directly against a DAO-owned proxy.
+#
+# The setter requires staking incentives to be paused (StakingIncentivesPaused / AllPaused); a fresh proxy
+# is StakingIncentivesPaused by construction, so no extra pause step is needed before this call.
+#
+# Usage: script_dispenser_change_managers.sh <network>
+#
+# Globals fields consumed:
+#   dispenserProxyAddress : live DispenserProxy address
+#   voteWeightingAddress  : Vote Weighting address to wire in
+
+# Check if $1 is provided
+if [ -z "$1" ]; then
+  echo "Usage: $0 <network>"
+  echo "Example: $0 mainnet"
+  exit 1
+fi
+
+red=$(tput setaf 1)
+green=$(tput setaf 2)
+reset=$(tput sgr0)
+
+# Get globals file
+globals="$(dirname "$0")/globals_$1.json"
+if [ ! -f $globals ]; then
+  echo "${red}!!! $globals is not found${reset}"
+  exit 0
+fi
+
+# Read variables using jq
+useLedger=$(jq -r '.useLedger' $globals)
+derivationPath=$(jq -r '.derivationPath' $globals)
+chainId=$(jq -r '.chainId' $globals)
+networkURL=$(jq -r '.networkURL' $globals)
+
+dispenserProxyAddress=$(jq -r '.dispenserProxyAddress' $globals)
+voteWeightingAddress=$(jq -r '.voteWeightingAddress' $globals)
+
+# Hard-fail on a missing/zero Vote Weighting — wiring the proxy to the zero address is a silent brick
+if [ -z "$voteWeightingAddress" ] || [ "$voteWeightingAddress" == "null" ] \
+   || [ "$voteWeightingAddress" == "0x0000000000000000000000000000000000000000" ]; then
+  echo "${red}!!! voteWeightingAddress is not set (or zero) in $globals${reset}"
+  exit 1
+fi
+
+if [ -z "$dispenserProxyAddress" ] || [ "$dispenserProxyAddress" == "null" ] \
+   || [ "$dispenserProxyAddress" == "0x0000000000000000000000000000000000000000" ]; then
+  echo "${red}!!! dispenserProxyAddress is not set (or zero) in $globals${reset}"
+  exit 1
+fi
+
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
+  fi
+fi
+
+# Get deployer based on the ledger flag
+if [ "$useLedger" == "true" ]; then
+  walletArgs="-l --mnemonic-derivation-path $derivationPath"
+  deployer=$(cast wallet address $walletArgs)
+else
+  echo "Using PRIVATE_KEY: ${PRIVATE_KEY:0:6}..."
+  walletArgs="--private-key $PRIVATE_KEY"
+  deployer=$(cast wallet address $walletArgs)
+fi
+
+castSendHeader="cast send --rpc-url $networkURL$API_KEY $walletArgs"
+
+zeroAddress="0x0000000000000000000000000000000000000000"
+
+echo "${green}Wire Vote Weighting into the DispenserProxy${reset}"
+echo "  dispenserProxy : $dispenserProxyAddress"
+echo "  voteWeighting  : $voteWeightingAddress"
+castArgs="$dispenserProxyAddress changeManagers(address,address) $zeroAddress $voteWeightingAddress"
+echo $castArgs
+castCmd="$castSendHeader $castArgs"
+result=$($castCmd)
+echo "$result" | grep "status"
+
+# Post-call sanity: the proxy must now report the wired Vote Weighting
+voteWeightingGetter=$(cast call --rpc-url $networkURL$API_KEY $dispenserProxyAddress "voteWeighting()(address)")
+echo "  voteWeighting() : $voteWeightingGetter (must be $voteWeightingAddress)"
+if [ "$(echo $voteWeightingGetter | tr '[:upper:]' '[:lower:]')" != "$(echo $voteWeightingAddress | tr '[:upper:]' '[:lower:]')" ]; then
+  echo "${red}!!! voteWeighting() does not match — wiring did not take effect${reset}"
+  exit 1
+fi
+echo "${green}Vote Weighting wired${reset}"

--- a/scripts/deployment/staking/deploy_01_mock_dispenser.js
+++ b/scripts/deployment/staking/deploy_01_mock_dispenser.js
@@ -43,7 +43,7 @@ async function main() {
     }
 
     // Writing updated parameters back to the JSON file
-    parsedData.dispenserAddress = dispenser.address;
+    parsedData.dispenserProxyAddress = dispenser.address;
     fs.writeFileSync(globalsFile, JSON.stringify(parsedData));
 
     // Contract verification

--- a/scripts/deployment/staking/deploy_02_arbitrum_deposit_processor.js
+++ b/scripts/deployment/staking/deploy_02_arbitrum_deposit_processor.js
@@ -30,7 +30,7 @@ async function main() {
     const ArbitrumDepositProcessorL1 = await ethers.getContractFactory("ArbitrumDepositProcessorL1");
     console.log("You are signing the following transaction: ArbitrumDepositProcessorL1.connect(EOA).deploy()");
     const arbitrumDepositProcessorL1 = await ArbitrumDepositProcessorL1.connect(EOA).deploy(parsedData.olasAddress,
-        parsedData.dispenserAddress, parsedData.arbitrumL1ERC20GatewayRouterAddress,
+        parsedData.dispenserProxyAddress, parsedData.arbitrumL1ERC20GatewayRouterAddress,
         parsedData.arbitrumInboxAddress, parsedData.arbitrumL2TargetChainId, parsedData.arbitrumL1ERC20GatewayAddress,
         parsedData.arbitrumOutboxAddress, parsedData.arbitrumBridgeAddress);
     const result = await arbitrumDepositProcessorL1.deployed();

--- a/scripts/deployment/staking/deploy_02_arbitrum_deposit_processor.sh
+++ b/scripts/deployment/staking/deploy_02_arbitrum_deposit_processor.sh
@@ -26,7 +26,7 @@ chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
 olasAddress=$(jq -r '.olasAddress' $globals)
-dispenserAddress=$(jq -r '.dispenserAddress' $globals)
+dispenserProxyAddress=$(jq -r '.dispenserProxyAddress' $globals)
 arbitrumL1ERC20GatewayRouterAddress=$(jq -r '.arbitrumL1ERC20GatewayRouterAddress' $globals)
 arbitrumInboxAddress=$(jq -r '.arbitrumInboxAddress' $globals)
 arbitrumL2TargetChainId=$(jq -r '.arbitrumL2TargetChainId' $globals)
@@ -50,7 +50,7 @@ if [[ "$networkURL" == *"alchemy.com"* ]]; then
 fi
 
 contractPath="contracts/staking/ArbitrumDepositProcessorL1.sol:ArbitrumDepositProcessorL1"
-constructorArgs="$olasAddress $dispenserAddress $arbitrumL1ERC20GatewayRouterAddress $arbitrumInboxAddress $arbitrumL2TargetChainId $arbitrumL1ERC20GatewayAddress $arbitrumOutboxAddress $arbitrumBridgeAddress"
+constructorArgs="$olasAddress $dispenserProxyAddress $arbitrumL1ERC20GatewayRouterAddress $arbitrumInboxAddress $arbitrumL2TargetChainId $arbitrumL1ERC20GatewayAddress $arbitrumOutboxAddress $arbitrumBridgeAddress"
 contractArgs="$contractPath --constructor-args $constructorArgs"
 
 # Get deployer based on the ledger flag

--- a/scripts/deployment/staking/deploy_03_gnosis_deposit_processor.js
+++ b/scripts/deployment/staking/deploy_03_gnosis_deposit_processor.js
@@ -30,7 +30,7 @@ async function main() {
     const GnosisDepositProcessorL1 = await ethers.getContractFactory("GnosisDepositProcessorL1");
     console.log("You are signing the following transaction: GnosisDepositProcessorL1.connect(EOA).deploy()");
     const gnosisDepositProcessorL1 = await GnosisDepositProcessorL1.connect(EOA).deploy(parsedData.olasAddress,
-        parsedData.dispenserAddress, parsedData.gnosisOmniBridgeAddress,
+        parsedData.dispenserProxyAddress, parsedData.gnosisOmniBridgeAddress,
         parsedData.gnosisAMBForeignAddress, parsedData.gnosisL2TargetChainId);
     const result = await gnosisDepositProcessorL1.deployed();
 

--- a/scripts/deployment/staking/deploy_03_gnosis_deposit_processor.sh
+++ b/scripts/deployment/staking/deploy_03_gnosis_deposit_processor.sh
@@ -26,7 +26,7 @@ chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
 olasAddress=$(jq -r '.olasAddress' $globals)
-dispenserAddress=$(jq -r '.dispenserAddress' $globals)
+dispenserProxyAddress=$(jq -r '.dispenserProxyAddress' $globals)
 gnosisOmniBridgeAddress=$(jq -r '.gnosisOmniBridgeAddress' $globals)
 gnosisAMBForeignAddress=$(jq -r '.gnosisAMBForeignAddress' $globals)
 gnosisL2TargetChainId=$(jq -r '.gnosisL2TargetChainId' $globals)
@@ -46,7 +46,7 @@ if [[ "$networkURL" == *"alchemy.com"* ]]; then
 fi
 
 contractPath="contracts/staking/GnosisDepositProcessorL1.sol:GnosisDepositProcessorL1"
-constructorArgs="$olasAddress $dispenserAddress $gnosisOmniBridgeAddress $gnosisAMBForeignAddress $gnosisL2TargetChainId"
+constructorArgs="$olasAddress $dispenserProxyAddress $gnosisOmniBridgeAddress $gnosisAMBForeignAddress $gnosisL2TargetChainId"
 contractArgs="$contractPath --constructor-args $constructorArgs"
 
 # Get deployer based on the ledger flag

--- a/scripts/deployment/staking/deploy_04_optimism_deposit_processor.js
+++ b/scripts/deployment/staking/deploy_04_optimism_deposit_processor.js
@@ -30,7 +30,7 @@ async function main() {
     const OptimismDepositProcessorL1 = await ethers.getContractFactory("OptimismDepositProcessorL1");
     console.log("You are signing the following transaction: OptimismDepositProcessorL1.connect(EOA).deploy()");
     const optimismDepositProcessorL1 = await OptimismDepositProcessorL1.connect(EOA).deploy(parsedData.olasAddress,
-        parsedData.dispenserAddress, parsedData.optimismL1StandardBridgeProxyAddress,
+        parsedData.dispenserProxyAddress, parsedData.optimismL1StandardBridgeProxyAddress,
         parsedData.optimismL1CrossDomainMessengerProxyAddress, parsedData.optimismL2TargetChainId,
         parsedData.optimismOLASAddress);
     const result = await optimismDepositProcessorL1.deployed();

--- a/scripts/deployment/staking/deploy_04_optimism_deposit_processor.sh
+++ b/scripts/deployment/staking/deploy_04_optimism_deposit_processor.sh
@@ -26,7 +26,7 @@ chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
 olasAddress=$(jq -r '.olasAddress' $globals)
-dispenserAddress=$(jq -r '.dispenserAddress' $globals)
+dispenserProxyAddress=$(jq -r '.dispenserProxyAddress' $globals)
 optimismL1StandardBridgeProxyAddress=$(jq -r '.optimismL1StandardBridgeProxyAddress' $globals)
 optimismL1CrossDomainMessengerProxyAddress=$(jq -r '.optimismL1CrossDomainMessengerProxyAddress' $globals)
 optimismL2TargetChainId=$(jq -r '.optimismL2TargetChainId' $globals)
@@ -47,7 +47,7 @@ if [[ "$networkURL" == *"alchemy.com"* ]]; then
 fi
 
 contractPath="contracts/staking/OptimismDepositProcessorL1.sol:OptimismDepositProcessorL1"
-constructorArgs="$olasAddress $dispenserAddress $optimismL1StandardBridgeProxyAddress $optimismL1CrossDomainMessengerProxyAddress $optimismL2TargetChainId $optimismOLASAddress"
+constructorArgs="$olasAddress $dispenserProxyAddress $optimismL1StandardBridgeProxyAddress $optimismL1CrossDomainMessengerProxyAddress $optimismL2TargetChainId $optimismOLASAddress"
 contractArgs="$contractPath --constructor-args $constructorArgs"
 
 # Get deployer based on the ledger flag

--- a/scripts/deployment/staking/deploy_05_celo_deposit_processor.js
+++ b/scripts/deployment/staking/deploy_05_celo_deposit_processor.js
@@ -30,7 +30,7 @@ async function main() {
     const WormholeDepositProcessorL1 = await ethers.getContractFactory("WormholeDepositProcessorL1");
     console.log("You are signing the following transaction: WormholeDepositProcessorL1.connect(EOA).deploy()");
     const celoDepositProcessorL1 = await WormholeDepositProcessorL1.connect(EOA).deploy(parsedData.olasAddress,
-        parsedData.dispenserAddress, parsedData.wormholeL1TokenRelayerAddress,
+        parsedData.dispenserProxyAddress, parsedData.wormholeL1TokenRelayerAddress,
         parsedData.wormholeL1MessageRelayerAddress, parsedData.celoL2TargetChainId,
         parsedData.wormholeL1CoreAddress, parsedData.celoWormholeL2TargetChainId);
     const result = await celoDepositProcessorL1.deployed();

--- a/scripts/deployment/staking/deploy_05_celo_deposit_processor.sh
+++ b/scripts/deployment/staking/deploy_05_celo_deposit_processor.sh
@@ -26,7 +26,7 @@ chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
 olasAddress=$(jq -r '.olasAddress' $globals)
-dispenserAddress=$(jq -r '.dispenserAddress' $globals)
+dispenserProxyAddress=$(jq -r '.dispenserProxyAddress' $globals)
 celoL1StandardBridgeProxyAddress=$(jq -r '.celoL1StandardBridgeProxyAddress' $globals)
 celoL1CrossDomainMessengerProxyAddress=$(jq -r '.celoL1CrossDomainMessengerProxyAddress' $globals)
 celoL2TargetChainId=$(jq -r '.celoL2TargetChainId' $globals)
@@ -47,7 +47,7 @@ if [[ "$networkURL" == *"alchemy.com"* ]]; then
 fi
 
 contractPath="contracts/staking/OptimismDepositProcessorL1.sol:OptimismDepositProcessorL1"
-constructorArgs="$olasAddress $dispenserAddress $celoL1StandardBridgeProxyAddress $celoL1CrossDomainMessengerProxyAddress $celoL2TargetChainId $celoOLASAddress"
+constructorArgs="$olasAddress $dispenserProxyAddress $celoL1StandardBridgeProxyAddress $celoL1CrossDomainMessengerProxyAddress $celoL2TargetChainId $celoOLASAddress"
 contractArgs="$contractPath --constructor-args $constructorArgs"
 
 # Get deployer based on the ledger flag

--- a/scripts/deployment/staking/deploy_06_polygon_deposit_processor.js
+++ b/scripts/deployment/staking/deploy_06_polygon_deposit_processor.js
@@ -30,7 +30,7 @@ async function main() {
     const PolygonDepositProcessorL1 = await ethers.getContractFactory("PolygonDepositProcessorL1");
     console.log("You are signing the following transaction: PolygonDepositProcessorL1.connect(EOA).deploy()");
     const polygonDepositProcessorL1 = await PolygonDepositProcessorL1.connect(EOA).deploy(parsedData.olasAddress,
-        parsedData.dispenserAddress, parsedData.polygonRootChainManagerProxyAddress,
+        parsedData.dispenserProxyAddress, parsedData.polygonRootChainManagerProxyAddress,
         parsedData.polygonFXRootAddress, parsedData.polygonL2TargetChainId, parsedData.polygonCheckpointManagerAddress,
         parsedData.polygonERC20PredicateAddress);
     const result = await polygonDepositProcessorL1.deployed();

--- a/scripts/deployment/staking/deploy_06_polygon_deposit_processor.sh
+++ b/scripts/deployment/staking/deploy_06_polygon_deposit_processor.sh
@@ -26,7 +26,7 @@ chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
 olasAddress=$(jq -r '.olasAddress' $globals)
-dispenserAddress=$(jq -r '.dispenserAddress' $globals)
+dispenserProxyAddress=$(jq -r '.dispenserProxyAddress' $globals)
 polygonRootChainManagerProxyAddress=$(jq -r '.polygonRootChainManagerProxyAddress' $globals)
 polygonFXRootAddress=$(jq -r '.polygonFXRootAddress' $globals)
 polygonL2TargetChainId=$(jq -r '.polygonL2TargetChainId' $globals)
@@ -48,7 +48,7 @@ if [[ "$networkURL" == *"alchemy.com"* ]]; then
 fi
 
 contractPath="contracts/staking/PolygonDepositProcessorL1.sol:PolygonDepositProcessorL1"
-constructorArgs="$olasAddress $dispenserAddress $polygonRootChainManagerProxyAddress $polygonFXRootAddress $polygonL2TargetChainId $polygonCheckpointManagerAddress $polygonERC20PredicateAddress"
+constructorArgs="$olasAddress $dispenserProxyAddress $polygonRootChainManagerProxyAddress $polygonFXRootAddress $polygonL2TargetChainId $polygonCheckpointManagerAddress $polygonERC20PredicateAddress"
 contractArgs="$contractPath --constructor-args $constructorArgs"
 
 # Get deployer based on the ledger flag

--- a/scripts/deployment/staking/deploy_07_base_deposit_processor.js
+++ b/scripts/deployment/staking/deploy_07_base_deposit_processor.js
@@ -30,7 +30,7 @@ async function main() {
     const OptimismDepositProcessorL1 = await ethers.getContractFactory("OptimismDepositProcessorL1");
     console.log("You are signing the following transaction: OptimismDepositProcessorL1.connect(EOA).deploy()");
     const baseDepositProcessorL1 = await OptimismDepositProcessorL1.connect(EOA).deploy(parsedData.olasAddress,
-        parsedData.dispenserAddress, parsedData.baseL1StandardBridgeProxyAddress,
+        parsedData.dispenserProxyAddress, parsedData.baseL1StandardBridgeProxyAddress,
         parsedData.baseL1CrossDomainMessengerProxyAddress, parsedData.baseL2TargetChainId,
         parsedData.baseOLASAddress);
     const result = await baseDepositProcessorL1.deployed();

--- a/scripts/deployment/staking/deploy_07_base_deposit_processor.sh
+++ b/scripts/deployment/staking/deploy_07_base_deposit_processor.sh
@@ -26,7 +26,7 @@ chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
 olasAddress=$(jq -r '.olasAddress' $globals)
-dispenserAddress=$(jq -r '.dispenserAddress' $globals)
+dispenserProxyAddress=$(jq -r '.dispenserProxyAddress' $globals)
 baseL1StandardBridgeProxyAddress=$(jq -r '.baseL1StandardBridgeProxyAddress' $globals)
 baseL1CrossDomainMessengerProxyAddress=$(jq -r '.baseL1CrossDomainMessengerProxyAddress' $globals)
 baseL2TargetChainId=$(jq -r '.baseL2TargetChainId' $globals)
@@ -47,7 +47,7 @@ if [[ "$networkURL" == *"alchemy.com"* ]]; then
 fi
 
 contractPath="contracts/staking/OptimismDepositProcessorL1.sol:OptimismDepositProcessorL1"
-constructorArgs="$olasAddress $dispenserAddress $baseL1StandardBridgeProxyAddress $baseL1CrossDomainMessengerProxyAddress $baseL2TargetChainId $baseOLASAddress"
+constructorArgs="$olasAddress $dispenserProxyAddress $baseL1StandardBridgeProxyAddress $baseL1CrossDomainMessengerProxyAddress $baseL2TargetChainId $baseOLASAddress"
 contractArgs="$contractPath --constructor-args $constructorArgs"
 
 # Get deployer based on the ledger flag

--- a/scripts/deployment/staking/deploy_08_eth_deposit_processor.js
+++ b/scripts/deployment/staking/deploy_08_eth_deposit_processor.js
@@ -30,7 +30,7 @@ async function main() {
     const EthereumDepositProcessor = await ethers.getContractFactory("EthereumDepositProcessor");
     console.log("You are signing the following transaction: EthereumDepositProcessor.connect(EOA).deploy()");
     const ethereumDepositProcessor = await EthereumDepositProcessor.connect(EOA).deploy(parsedData.olasAddress,
-        parsedData.dispenserAddress, parsedData.serviceStakingFactoryAddress, parsedData.timelockAddress);
+        parsedData.dispenserProxyAddress, parsedData.serviceStakingFactoryAddress, parsedData.timelockAddress);
     const result = await ethereumDepositProcessor.deployed();
 
     // Transaction details

--- a/scripts/deployment/staking/deploy_08_eth_deposit_processor.sh
+++ b/scripts/deployment/staking/deploy_08_eth_deposit_processor.sh
@@ -19,7 +19,7 @@ chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
 olasAddress=$(jq -r '.olasAddress' $globals)
-dispenserAddress=$(jq -r '.dispenserAddress' $globals)
+dispenserProxyAddress=$(jq -r '.dispenserProxyAddress' $globals)
 serviceStakingFactoryAddress=$(jq -r '.serviceStakingFactoryAddress' $globals)
 timelockAddress=$(jq -r '.timelockAddress' $globals)
 
@@ -38,7 +38,7 @@ if [[ "$networkURL" == *"alchemy.com"* ]]; then
 fi
 
 contractPath="contracts/staking/EthereumDepositProcessor.sol:EthereumDepositProcessor"
-constructorArgs="$olasAddress $dispenserAddress $serviceStakingFactoryAddress $timelockAddress"
+constructorArgs="$olasAddress $dispenserProxyAddress $serviceStakingFactoryAddress $timelockAddress"
 contractArgs="$contractPath --constructor-args $constructorArgs"
 
 # Get deployer based on the ledger flag

--- a/scripts/deployment/staking/deploy_10_set_deposit_processors.js
+++ b/scripts/deployment/staking/deploy_10_set_deposit_processors.js
@@ -18,7 +18,7 @@ async function main() {
     const optimismDepositProcessorL1Address = parsedData.optimismDepositProcessorL1Address;
     const polygonDepositProcessorL1Address = parsedData.polygonDepositProcessorL1Address;
     const ethereumDepositProcessorAddress = parsedData.ethereumDepositProcessorAddress;
-    const dispenserAddress = parsedData.dispenserAddress;
+    const dispenserProxyAddress = parsedData.dispenserProxyAddress;
     let EOA;
 
     const provider = await ethers.providers.getDefaultProvider(providerName);
@@ -40,7 +40,7 @@ async function main() {
     const gnosisDepositProcessorL1 = await ethers.getContractAt("GnosisDepositProcessorL1", gnosisDepositProcessorL1Address);
     const optimismDepositProcessorL1 = await ethers.getContractAt("OptimismDepositProcessorL1", optimismDepositProcessorL1Address);
     const polygonDepositProcessorL1 = await ethers.getContractAt("PolygonDepositProcessorL1", polygonDepositProcessorL1Address);
-    const dispenser = await ethers.getContractAt("Dispenser", dispenserAddress);
+    const dispenser = await ethers.getContractAt("Dispenser", dispenserProxyAddress);
 
     // Transaction signing and execution
     console.log("10. EOA to set deposit processors in Dispenser");

--- a/scripts/deployment/staking/deploy_11_mode_deposit_processor.js
+++ b/scripts/deployment/staking/deploy_11_mode_deposit_processor.js
@@ -30,7 +30,7 @@ async function main() {
     const OptimismDepositProcessorL1 = await ethers.getContractFactory("OptimismDepositProcessorL1");
     console.log("You are signing the following transaction: OptimismDepositProcessorL1.connect(EOA).deploy()");
     const modeDepositProcessorL1 = await OptimismDepositProcessorL1.connect(EOA).deploy(parsedData.olasAddress,
-        parsedData.dispenserAddress, parsedData.modeL1StandardBridgeProxyAddress,
+        parsedData.dispenserProxyAddress, parsedData.modeL1StandardBridgeProxyAddress,
         parsedData.modeL1CrossDomainMessengerProxyAddress, parsedData.modeL2TargetChainId,
         parsedData.modeOLASAddress, {gasLimit: 2000000});
     const result = await modeDepositProcessorL1.deployed();

--- a/scripts/deployment/staking/deploy_11_mode_deposit_processor.sh
+++ b/scripts/deployment/staking/deploy_11_mode_deposit_processor.sh
@@ -26,7 +26,7 @@ chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
 olasAddress=$(jq -r '.olasAddress' $globals)
-dispenserAddress=$(jq -r '.dispenserAddress' $globals)
+dispenserProxyAddress=$(jq -r '.dispenserProxyAddress' $globals)
 modeL1StandardBridgeProxyAddress=$(jq -r '.modeL1StandardBridgeProxyAddress' $globals)
 modeL1CrossDomainMessengerProxyAddress=$(jq -r '.modeL1CrossDomainMessengerProxyAddress' $globals)
 modeL2TargetChainId=$(jq -r '.modeL2TargetChainId' $globals)
@@ -47,7 +47,7 @@ if [[ "$networkURL" == *"alchemy.com"* ]]; then
 fi
 
 contractPath="contracts/staking/OptimismDepositProcessorL1.sol:OptimismDepositProcessorL1"
-constructorArgs="$olasAddress $dispenserAddress $modeL1StandardBridgeProxyAddress $modeL1CrossDomainMessengerProxyAddress $modeL2TargetChainId $modeOLASAddress"
+constructorArgs="$olasAddress $dispenserProxyAddress $modeL1StandardBridgeProxyAddress $modeL1CrossDomainMessengerProxyAddress $modeL2TargetChainId $modeOLASAddress"
 contractArgs="$contractPath --constructor-args $constructorArgs"
 
 # Get deployer moded on the ledger flag

--- a/scripts/deployment/staking/verify_02_arbitrum_deposit_processor.js
+++ b/scripts/deployment/staking/verify_02_arbitrum_deposit_processor.js
@@ -5,7 +5,7 @@ const parsedData = JSON.parse(dataFromJSON);
 
 module.exports = [
     parsedData.olasAddress,
-    parsedData.dispenserAddress,
+    parsedData.dispenserProxyAddress,
     parsedData.arbitrumL1ERC20GatewayRouterAddress,
     parsedData.arbitrumInboxAddress,
     parsedData.arbitrumL2TargetChainId,

--- a/scripts/deployment/staking/verify_03_gnosis_deposit_processor.js
+++ b/scripts/deployment/staking/verify_03_gnosis_deposit_processor.js
@@ -5,7 +5,7 @@ const parsedData = JSON.parse(dataFromJSON);
 
 module.exports = [
     parsedData.olasAddress,
-    parsedData.dispenserAddress,
+    parsedData.dispenserProxyAddress,
     parsedData.gnosisOmniBridgeAddress,
     parsedData.gnosisAMBForeignAddress,
     parsedData.gnosisL2TargetChainId

--- a/scripts/deployment/staking/verify_04_optimism_deposit_processor.js
+++ b/scripts/deployment/staking/verify_04_optimism_deposit_processor.js
@@ -5,7 +5,7 @@ const parsedData = JSON.parse(dataFromJSON);
 
 module.exports = [
     parsedData.olasAddress,
-    parsedData.dispenserAddress,
+    parsedData.dispenserProxyAddress,
     parsedData.optimismL1StandardBridgeProxyAddress,
     parsedData.optimismL1CrossDomainMessengerProxyAddress,
     parsedData.optimismL2TargetChainId,

--- a/scripts/deployment/staking/verify_05_celo_deposit_processor.js
+++ b/scripts/deployment/staking/verify_05_celo_deposit_processor.js
@@ -5,7 +5,7 @@ const parsedData = JSON.parse(dataFromJSON);
 
 module.exports = [
     parsedData.olasAddress,
-    parsedData.dispenserAddress,
+    parsedData.dispenserProxyAddress,
     parsedData.wormholeL1TokenRelayerAddress,
     parsedData.wormholeL1MessageRelayerAddress,
     parsedData.celoL2TargetChainId,

--- a/scripts/deployment/staking/verify_06_polygon_deposit_processor.js
+++ b/scripts/deployment/staking/verify_06_polygon_deposit_processor.js
@@ -5,7 +5,7 @@ const parsedData = JSON.parse(dataFromJSON);
 
 module.exports = [
     parsedData.olasAddress,
-    parsedData.dispenserAddress,
+    parsedData.dispenserProxyAddress,
     parsedData.polygonRootChainManagerProxyAddress,
     parsedData.polygonFXRootAddress,
     parsedData.polygonL2TargetChainId,

--- a/scripts/deployment/staking/verify_07_base_deposit_processor.js
+++ b/scripts/deployment/staking/verify_07_base_deposit_processor.js
@@ -5,7 +5,7 @@ const parsedData = JSON.parse(dataFromJSON);
 
 module.exports = [
     parsedData.olasAddress,
-    parsedData.dispenserAddress,
+    parsedData.dispenserProxyAddress,
     parsedData.baseL1StandardBridgeProxyAddress,
     parsedData.baseL1CrossDomainMessengerProxyAddress,
     parsedData.baseL2TargetChainId,

--- a/scripts/deployment/staking/verify_08_ethereum_deposit_processor.js
+++ b/scripts/deployment/staking/verify_08_ethereum_deposit_processor.js
@@ -5,7 +5,7 @@ const parsedData = JSON.parse(dataFromJSON);
 
 module.exports = [
     parsedData.olasAddress,
-    parsedData.dispenserAddress,
+    parsedData.dispenserProxyAddress,
     parsedData.serviceStakingFactoryAddress,
     parsedData.timelockAddress
 ];

--- a/scripts/deployment/staking/verify_11_mode_deposit_processor.js
+++ b/scripts/deployment/staking/verify_11_mode_deposit_processor.js
@@ -5,7 +5,7 @@ const parsedData = JSON.parse(dataFromJSON);
 
 module.exports = [
     parsedData.olasAddress,
-    parsedData.dispenserAddress,
+    parsedData.dispenserProxyAddress,
     parsedData.modeL1StandardBridgeProxyAddress,
     parsedData.modeL1CrossDomainMessengerProxyAddress,
     parsedData.modeL2TargetChainId,

--- a/scripts/fork/tokenomics_retain_calculation.js
+++ b/scripts/fork/tokenomics_retain_calculation.js
@@ -22,7 +22,7 @@ async function main() {
     // Get all the necessary contract addresses
     const timelockAddress = parsedData.timelockAddress;
     const tokenomicsProxyAddress = parsedData.tokenomicsProxyAddress;
-    const dispenserAddress = parsedData.dispenserAddress;
+    const dispenserProxyAddress = parsedData.dispenserProxyAddress;
 
     // Timelock address is specified via the "-u" command to ganache node
     const signer = provider.getSigner(timelockAddress);
@@ -46,7 +46,7 @@ async function main() {
     abi = parsedFile["abi"];
 
     // Tokenomics contract instance
-    const dispenser = new ethers.Contract(dispenserAddress, abi, wallet);
+    const dispenser = new ethers.Contract(dispenserProxyAddress, abi, wallet);
     console.log("Dispenser address", dispenser.address);
 
     const epochCounter = await tokenomics.epochCounter();

--- a/scripts/proposals/proposal_09_change_dispenser_and_disable_previous_one.js
+++ b/scripts/proposals/proposal_09_change_dispenser_and_disable_previous_one.js
@@ -14,7 +14,7 @@ async function main() {
     // Get all the necessary contract addresses
     const tokenomicsProxyAddress = parsedData.tokenomicsProxyAddress;
     const treasuryAddress = parsedData.treasuryAddress;
-    const dispenserAddress = parsedData.dispenserAddress;
+    const dispenserProxyAddress = parsedData.dispenserProxyAddress;
     const arbitrumDepositProcessorL1Address = parsedData.arbitrumDepositProcessorL1Address;
     const baseDepositProcessorL1Address = parsedData.baseDepositProcessorL1Address;
     const celoDepositProcessorL1Address = parsedData.celoDepositProcessorL1Address;
@@ -45,9 +45,9 @@ async function main() {
         oldDispenserAddress];
     const values = [0, 0, 0, 0, 0];
     const callDatas = [
-        tokenomics.interface.encodeFunctionData("changeManagers", [AddressZero, AddressZero, dispenserAddress]),
+        tokenomics.interface.encodeFunctionData("changeManagers", [AddressZero, AddressZero, dispenserProxyAddress]),
         tokenomics.interface.encodeFunctionData("changeStakingParams", [maxStakingIncentive, minStakingWeight]),
-        treasury.interface.encodeFunctionData("changeManagers", [AddressZero, AddressZero, dispenserAddress]),
+        treasury.interface.encodeFunctionData("changeManagers", [AddressZero, AddressZero, dispenserProxyAddress]),
         oldDispenser.interface.encodeFunctionData("changeManagers", [AddressNull, AddressNull]),
         oldDispenser.interface.encodeFunctionData("changeOwner", [AddressNull])
     ];

--- a/scripts/proposals/proposal_10_dispenser_set_deposit_processor_chain_ids.js
+++ b/scripts/proposals/proposal_10_dispenser_set_deposit_processor_chain_ids.js
@@ -12,7 +12,7 @@ async function main() {
     const provider = await ethers.providers.getDefaultProvider(providerName);
 
     // Get all the necessary contract addresses
-    const dispenserAddress = parsedData.dispenserAddress;
+    const dispenserProxyAddress = parsedData.dispenserProxyAddress;
     const depositProcessorL1Addresses = [parsedData.arbitrumDepositProcessorL1Address, parsedData.baseDepositProcessorL1Address,
         parsedData.celoDepositProcessorL1Address, parsedData.gnosisDepositProcessorL1Address,
         parsedData.modeDepositProcessorL1Address, parsedData.optimismDepositProcessorL1Address,
@@ -22,11 +22,11 @@ async function main() {
         parsedData.optimismL2TargetChainId, parsedData.polygonL2TargetChainId];
 
     // Get dispenser contract instance
-    const dispenser = await ethers.getContractAt("Dispenser", dispenserAddress);
+    const dispenser = await ethers.getContractAt("Dispenser", dispenserProxyAddress);
 
     // Proposal preparation
     console.log("Proposal 10. Set Deposit Processor and Chain Id in Dispenser for Mode");
-    const targets = [dispenserAddress];
+    const targets = [dispenserProxyAddress];
     const values = [0];
     const callDatas = [
         dispenser.interface.encodeFunctionData("setDepositProcessorChainIds", [depositProcessorL1Addresses, l2TargetChainIds])

--- a/test/Dispenser.t.sol
+++ b/test/Dispenser.t.sol
@@ -73,7 +73,7 @@ contract BaseSetup is Test {
 
         // Deploy dispenser implementation (tokenomics proxy address is an implementation immutable) and proxy
         // Vote Weighting contract is irrelevant here, so we are using a deployer's address
-        Dispenser dispenserMaster = new Dispenser(address(olas), address(tokenomics), retainer, 100, 1 ether);
+        Dispenser dispenserMaster = new Dispenser(address(olas), address(tokenomics), retainer);
         bytes memory dispenserData = abi.encodeWithSelector(dispenserMaster.initialize.selector,
             address(treasury), deployer, 100, 100);
         DispenserProxy dispenserProxy = new DispenserProxy(address(dispenserMaster), dispenserData);

--- a/test/DispenserDevIncentives.js
+++ b/test/DispenserDevIncentives.js
@@ -166,9 +166,11 @@ describe("DispenserDevIncentives", async () => {
             await expect(
                 dispenserMaster.initialize(AddressZero, AddressZero, 0, 0)
             ).to.be.revertedWithCustomError(dispenser, "ZeroAddress");
+            // Vote Weighting is allowed to be zero at init (wired later via changeManagers), so a zero VW no
+            // longer trips ZeroAddress — this call fails on the zero maxNumClaimingEpochs instead
             await expect(
                 dispenserMaster.initialize(deployer.address, AddressZero, 0, 0)
-            ).to.be.revertedWithCustomError(dispenser, "ZeroAddress");
+            ).to.be.revertedWithCustomError(dispenser, "ZeroValue");
             await expect(
                 dispenserMaster.initialize(deployer.address, deployer.address, 0, 0)
             ).to.be.revertedWithCustomError(dispenser, "ZeroValue");
@@ -176,8 +178,13 @@ describe("DispenserDevIncentives", async () => {
                 dispenserMaster.initialize(deployer.address, deployer.address, 10, 0)
             ).to.be.revertedWithCustomError(dispenser, "ZeroValue");
 
-            // Initialize and check that a repeated initialization is not possible
-            await dispenserMaster.initialize(deployer.address, deployer.address, 10, 10);
+            // Initialize with a ZERO Vote Weighting (allowed: it is deployed against the proxy address
+            // afterwards and wired via changeManagers), then check that a repeated initialization is not possible
+            await dispenserMaster.initialize(deployer.address, AddressZero, 10, 10);
+            expect(await dispenserMaster.voteWeighting()).to.equal(AddressZero);
+            // Wire the real Vote Weighting in afterwards while staking incentives are paused
+            await dispenserMaster.changeManagers(AddressZero, deployer.address);
+            expect(await dispenserMaster.voteWeighting()).to.equal(deployer.address);
             await expect(
                 dispenserMaster.initialize(deployer.address, deployer.address, 10, 10)
             ).to.be.revertedWithCustomError(dispenser, "AlreadyInitialized");

--- a/test/DispenserDevIncentives.js
+++ b/test/DispenserDevIncentives.js
@@ -10,10 +10,7 @@ describe("DispenserDevIncentives", async () => {
     const oneMonth = 86400 * 30;
     const maxNumClaimingEpochs = 10;
     const maxNumStakingTargets = 100;
-    const defaultMinStakingWeight = 100;
-    const defaultMaxStakingIncentive = ethers.utils.parseEther("1");
     const retainer = "0x" + "5".repeat(64);
-    const moreThanMaxUint96 = "79228162514264337593543950337";
 
     let signers;
     let deployer;
@@ -78,8 +75,7 @@ describe("DispenserDevIncentives", async () => {
 
         // Deploy dispenser master implementation (tokenomics proxy address is an implementation immutable)
         const Dispenser = await ethers.getContractFactory("Dispenser");
-        const dispenserMaster = await Dispenser.deploy(olas.address, tokenomics.address, retainer,
-            defaultMinStakingWeight, defaultMaxStakingIncentive);
+        const dispenserMaster = await Dispenser.deploy(olas.address, tokenomics.address, retainer);
         await dispenserMaster.deployed();
 
         // Deploy dispenser proxy; Vote Weighting contract is irrelevant here, so we are using a deployer's address
@@ -152,31 +148,19 @@ describe("DispenserDevIncentives", async () => {
         it("Should fail if deploying a dispenser with a zero address", async function () {
             const Dispenser = await ethers.getContractFactory("Dispenser");
             await expect(
-                Dispenser.deploy(AddressZero, AddressZero, HashZero, 0, 0)
+                Dispenser.deploy(AddressZero, AddressZero, HashZero)
             ).to.be.revertedWithCustomError(dispenser, "ZeroAddress");
             await expect(
-                Dispenser.deploy(deployer.address, AddressZero, HashZero, 0, 0)
+                Dispenser.deploy(deployer.address, AddressZero, HashZero)
             ).to.be.revertedWithCustomError(dispenser, "ZeroAddress");
             await expect(
-                Dispenser.deploy(deployer.address, deployer.address, HashZero, 0, 0)
+                Dispenser.deploy(deployer.address, deployer.address, HashZero)
             ).to.be.revertedWithCustomError(dispenser, "ZeroAddress");
-            await expect(
-                Dispenser.deploy(deployer.address, deployer.address, retainer, 0, 0)
-            ).to.be.revertedWithCustomError(dispenser, "ZeroValue");
-            await expect(
-                Dispenser.deploy(deployer.address, deployer.address, retainer, 10, 0)
-            ).to.be.revertedWithCustomError(dispenser, "ZeroValue");
-            await expect(
-                Dispenser.deploy(deployer.address, deployer.address, retainer, moreThanMaxUint96, moreThanMaxUint96)
-            ).to.be.revertedWithCustomError(dispenser, "Overflow");
-            await expect(
-                Dispenser.deploy(deployer.address, deployer.address, retainer, 10, moreThanMaxUint96)
-            ).to.be.revertedWithCustomError(dispenser, "Overflow");
         });
 
         it("Should fail when initializing with incorrect values or twice", async function () {
             const Dispenser = await ethers.getContractFactory("Dispenser");
-            const dispenserMaster = await Dispenser.deploy(deployer.address, deployer.address, retainer, 10, 10);
+            const dispenserMaster = await Dispenser.deploy(deployer.address, deployer.address, retainer);
             await dispenserMaster.deployed();
 
             await expect(

--- a/test/DispenserFixes.t.sol
+++ b/test/DispenserFixes.t.sol
@@ -87,7 +87,7 @@ contract DispenserFixesTest is Test {
         tokenomics = Tokenomics(address(tokenomicsProxy));
 
         // Deploy dispenser implementation and proxy
-        Dispenser dispenserMaster = new Dispenser(address(olas), address(tokenomics), retainer, 100, 1 ether);
+        Dispenser dispenserMaster = new Dispenser(address(olas), address(tokenomics), retainer);
         bytes memory dispenserData = abi.encodeWithSelector(dispenserMaster.initialize.selector,
             address(treasury), deployer, 100, 100);
         DispenserProxy dispenserProxy = new DispenserProxy(address(dispenserMaster), dispenserData);
@@ -113,6 +113,8 @@ contract DispenserFixesTest is Test {
 
         // Enable staking inflation from the next epoch and settle two epochs so a claimable epoch exists
         tokenomics.changeIncentiveFractions(0, 0, 0, 0, 0, 50);
+        // Staking parameters (maxStakingIncentive, minStakingWeight) — always non-zero on a live Tokenomics
+        tokenomics.changeStakingParams(1 ether, 100);
 
         // Unpause staking incentives (nominees cannot be added while paused)
         dispenser.setPauseState(Dispenser.Pause.Unpaused);

--- a/test/DispenserProxy.t.sol
+++ b/test/DispenserProxy.t.sol
@@ -24,7 +24,7 @@ contract DispenserProxyTest is Test {
     Dispenser internal dispenser;
 
     function setUp() public {
-        dispenserMaster = new Dispenser(OLAS, TOKENOMICS, RETAINER, 100, 1 ether);
+        dispenserMaster = new Dispenser(OLAS, TOKENOMICS, RETAINER);
         bytes memory initData = abi.encodeWithSelector(Dispenser.initialize.selector,
             TREASURY, VOTE_WEIGHTING, 10, 20);
         DispenserProxy proxy = new DispenserProxy(address(dispenserMaster), initData);
@@ -71,8 +71,6 @@ contract DispenserProxyTest is Test {
         assertEq(dispenser.olas(), OLAS, "olas");
         assertEq(dispenser.tokenomics(), TOKENOMICS, "tokenomics");
         assertEq(dispenser.retainer(), RETAINER, "retainer");
-        assertEq(dispenser.defaultMinStakingWeight(), 100, "defaultMinStakingWeight");
-        assertEq(dispenser.defaultMaxStakingIncentive(), 1 ether, "defaultMaxStakingIncentive");
 
         // The implementation address sits in the dedicated proxy slot
         bytes32 rawImplementation = vm.load(address(dispenser), PROXY_DISPENSER);
@@ -108,11 +106,12 @@ contract DispenserProxyTest is Test {
     }
 
     function test_changeImplementation_swapsLogicAndPreservesState() public {
-        // Mutate proxy storage first so preservation is observable
-        dispenser.changeStakingParams(42, 84);
+        // Mutate proxy storage after init so preservation is observable
+        address newTreasury = address(0x7EA52);
+        dispenser.changeManagers(newTreasury, address(0));
 
-        // New implementation with different immutables (models a fixed / re-parameterized build)
-        Dispenser newMaster = new Dispenser(OLAS, TOKENOMICS, RETAINER, 200, 2 ether);
+        // New implementation build
+        Dispenser newMaster = new Dispenser(OLAS, TOKENOMICS, RETAINER);
 
         vm.expectEmit(true, false, false, false, address(dispenser));
         emit ImplementationUpdated(address(newMaster));
@@ -124,14 +123,15 @@ contract DispenserProxyTest is Test {
 
         // Proxy storage preserved across the upgrade
         assertEq(dispenser.owner(), address(this), "owner preserved");
-        assertEq(dispenser.treasury(), TREASURY, "treasury preserved");
+        assertEq(dispenser.treasury(), newTreasury, "treasury preserved");
         assertEq(dispenser.voteWeighting(), VOTE_WEIGHTING, "voteWeighting preserved");
-        assertEq(dispenser.maxNumClaimingEpochs(), 42, "maxNumClaimingEpochs preserved");
-        assertEq(dispenser.maxNumStakingTargets(), 84, "maxNumStakingTargets preserved");
+        assertEq(dispenser.maxNumClaimingEpochs(), 10, "maxNumClaimingEpochs preserved");
+        assertEq(dispenser.maxNumStakingTargets(), 20, "maxNumStakingTargets preserved");
         assertEq(uint256(dispenser.paused()), uint256(Dispenser.Pause.StakingIncentivesPaused), "paused preserved");
 
         // Immutable reads now come from the new implementation bytecode
-        assertEq(dispenser.defaultMinStakingWeight(), 200, "new defaultMinStakingWeight");
-        assertEq(dispenser.defaultMaxStakingIncentive(), 2 ether, "new defaultMaxStakingIncentive");
+        assertEq(dispenser.olas(), OLAS, "olas");
+        assertEq(dispenser.tokenomics(), TOKENOMICS, "tokenomics");
+        assertEq(dispenser.retainer(), RETAINER, "retainer");
     }
 }

--- a/test/DispenserProxy.t.sol
+++ b/test/DispenserProxy.t.sol
@@ -77,6 +77,24 @@ contract DispenserProxyTest is Test {
         assertEq(address(uint160(uint256(rawImplementation))), address(dispenserMaster), "implementation slot");
     }
 
+    function test_initialize_zeroVoteWeighting_allowed() public {
+        // A fresh proxy is deployed with a zero Vote Weighting on purpose: VoteWeighting binds this proxy's
+        // address as an immutable, so it does not exist yet at init. It is wired later via changeManagers.
+        Dispenser master = new Dispenser(OLAS, TOKENOMICS, RETAINER);
+        bytes memory initData = abi.encodeWithSelector(Dispenser.initialize.selector,
+            TREASURY, address(0), 10, 20);
+        Dispenser proxied = Dispenser(address(new DispenserProxy(address(master), initData)));
+
+        assertEq(proxied.voteWeighting(), address(0), "voteWeighting zero at init");
+        assertEq(proxied.treasury(), TREASURY, "treasury set");
+        // Still paused, so no claim path can run against the zero Vote Weighting
+        assertEq(uint256(proxied.paused()), uint256(Dispenser.Pause.StakingIncentivesPaused), "paused");
+
+        // changeManagers wires the real Vote Weighting while paused
+        proxied.changeManagers(address(0), VOTE_WEIGHTING);
+        assertEq(proxied.voteWeighting(), VOTE_WEIGHTING, "voteWeighting wired");
+    }
+
     function test_initialize_proxyReinit_reverts() public {
         vm.expectRevert(AlreadyInitialized.selector);
         dispenser.initialize(TREASURY, VOTE_WEIGHTING, 10, 20);

--- a/test/DispenserStakingIncentives.js
+++ b/test/DispenserStakingIncentives.js
@@ -20,8 +20,6 @@ describe("DispenserStakingIncentives", async () => {
     const delta = 100;
     const maxNumClaimingEpochs = 10;
     const maxNumStakingTargets = 100;
-    const defaultMinStakingWeight = 100;
-    const defaultMaxStakingIncentive = ethers.utils.parseEther("1");
     const maxUint256 = ethers.constants.MaxUint256;
     const defaultGasLimit = "2000000";
     const retainer = "0x" + "0".repeat(24) + "5".repeat(40);
@@ -94,8 +92,7 @@ describe("DispenserStakingIncentives", async () => {
 
         // Deploy dispenser master implementation (tokenomics proxy address is an implementation immutable)
         const Dispenser = await ethers.getContractFactory("Dispenser");
-        const dispenserMaster = await Dispenser.deploy(olas.address, tokenomics.address, retainer,
-            defaultMinStakingWeight, defaultMaxStakingIncentive);
+        const dispenserMaster = await Dispenser.deploy(olas.address, tokenomics.address, retainer);
         await dispenserMaster.deployed();
 
         // Deploy dispenser proxy; Vote Weighting address is a placeholder until the mock is deployed below
@@ -218,24 +215,6 @@ describe("DispenserStakingIncentives", async () => {
             await expect(
                 vw.removeNominee(stakingInstance.address, chainId)
             ).to.be.revertedWithCustomError(dispenser, "Overflow");
-        });
-
-        it("Changing staking parameters", async () => {
-            // Should fail when not called by the owner
-            await expect(
-                dispenser.connect(signers[1]).changeStakingParams(0, 0)
-            ).to.be.revertedWithCustomError(dispenser, "OwnerOnly");
-
-            // Set arbitrary parameters
-            await dispenser.changeStakingParams(10, 10);
-
-            // Trying to set parameters to zero
-            await expect(
-                dispenser.changeStakingParams(0, 0)
-            ).to.be.revertedWithCustomError(dispenser, "ZeroValue");
-            await expect(
-                dispenser.changeStakingParams(10, 0)
-            ).to.be.revertedWithCustomError(dispenser, "ZeroValue");
         });
 
         it("Should fail when setting deposit processors and chain Ids with incorrect parameters", async () => {
@@ -569,22 +548,32 @@ describe("DispenserStakingIncentives", async () => {
                     bridgePayloads, [0, 1])
             ).to.be.revertedWithCustomError(dispenser, "WrongAmount");
 
-            // Change dispenser staking params
-            await dispenser.changeStakingParams(1, 1);
+            // maxNumClaimingEpochs and maxNumStakingTargets are fixed at initialize(); deploy a
+            // small-bounds dispenser (1, 1) to exercise the input-bound Overflow checks
+            const Dispenser = await ethers.getContractFactory("Dispenser");
+            const dispenserSmallMaster = await Dispenser.deploy(olas.address, tokenomics.address, retainer);
+            await dispenserSmallMaster.deployed();
+            const dispenserSmallData = dispenserSmallMaster.interface.encodeFunctionData("initialize",
+                [treasury.address, vw.address, 1, 1]);
+            const DispenserProxy = await ethers.getContractFactory("DispenserProxy");
+            const dispenserSmallProxy = await DispenserProxy.deploy(dispenserSmallMaster.address, dispenserSmallData);
+            await dispenserSmallProxy.deployed();
+            const dispenserSmall = await ethers.getContractAt("Dispenser", dispenserSmallProxy.address);
+
             // Too many staking targets
             await expect(
-                dispenser.claimStakingIncentivesBatch(numClaimedEpochs, [chainId], [[stakingTargets[1], stakingTargets[0]]],
+                dispenserSmall.claimStakingIncentivesBatch(numClaimedEpochs, [chainId], [[stakingTargets[1], stakingTargets[0]]],
                     [bridgePayloads[0]], [valueAmounts[0]])
-            ).to.be.revertedWithCustomError(dispenser, "Overflow");
+            ).to.be.revertedWithCustomError(dispenserSmall, "Overflow");
 
             // Too many epochs to claim for
             await expect(
-                dispenser.claimStakingIncentivesBatch(numClaimedEpochs + 1, chainIds, stakingTargetsFinal,
+                dispenserSmall.claimStakingIncentivesBatch(numClaimedEpochs + 1, chainIds, stakingTargetsFinal,
                     bridgePayloads, valueAmounts)
-            ).to.be.revertedWithCustomError(dispenser, "Overflow");
+            ).to.be.revertedWithCustomError(dispenserSmall, "Overflow");
             await expect(
-                dispenser.claimStakingIncentives(numClaimedEpochs + 1, chainId, stakingTargets[0], bridgePayloads[0])
-            ).to.be.revertedWithCustomError(dispenser, "Overflow");
+                dispenserSmall.claimStakingIncentives(numClaimedEpochs + 1, chainId, stakingTargets[0], bridgePayloads[0])
+            ).to.be.revertedWithCustomError(dispenserSmall, "Overflow");
 
             // Trying to claim when staking is paused
             await dispenser.setPauseState(2);

--- a/test/StakingClaimForkETH.t.sol
+++ b/test/StakingClaimForkETH.t.sol
@@ -133,11 +133,12 @@ contract StakingClaimForkETH is Test {
     function setUp() public {
         epochLen = ITokenomicsFork(TOKENOMICS).epochLen();
 
-        // Deploy the new Dispenser implementation against the LIVE Tokenomics proxy, then the proxy.
-        // Vote Weighting is a placeholder here (set after the proxy exists, under the initial pause).
+        // Deploy the new Dispenser implementation against the LIVE Tokenomics proxy, then the proxy. Vote
+        // Weighting is initialized to the zero address (it is deployed against the proxy address afterwards,
+        // exactly as on mainnet), then wired via changeManagers under the initial pause.
         Dispenser dispenserImpl = new Dispenser(OLAS, TOKENOMICS, RETAINER);
         bytes memory initData = abi.encodeWithSelector(dispenserImpl.initialize.selector,
-            TREASURY, address(this), uint256(1), uint256(10));
+            TREASURY, address(0), uint256(1), uint256(10));
         DispenserProxy dispenserProxy = new DispenserProxy(address(dispenserImpl), initData);
         dispenser = Dispenser(address(dispenserProxy));
 

--- a/test/StakingClaimForkETH.t.sol
+++ b/test/StakingClaimForkETH.t.sol
@@ -118,10 +118,8 @@ contract StakingClaimForkETH is Test {
     address internal constant TREASURY = 0xa0DA53447C0f6C4987964d8463da7e6628B30f82;
     address internal constant TIMELOCK = 0x3C1fF68f5aa342D296d4DEe4Bb1cACCA912D95fE;
 
-    // Dispenser implementation immutables (mainnet defaults)
+    // Dispenser implementation immutable
     bytes32 internal constant RETAINER = bytes32(uint256(0xdEaD));
-    uint256 internal constant DEFAULT_MIN_STAKING_WEIGHT = 50;
-    uint256 internal constant DEFAULT_MAX_STAKING_INCENTIVE = 60_000 ether;
 
     // A non-L1 EVM chain Id for the staking target (must differ from block.chainid == 1)
     uint256 internal constant CHAIN_ID = 100;
@@ -137,8 +135,7 @@ contract StakingClaimForkETH is Test {
 
         // Deploy the new Dispenser implementation against the LIVE Tokenomics proxy, then the proxy.
         // Vote Weighting is a placeholder here (set after the proxy exists, under the initial pause).
-        Dispenser dispenserImpl =
-            new Dispenser(OLAS, TOKENOMICS, RETAINER, DEFAULT_MIN_STAKING_WEIGHT, DEFAULT_MAX_STAKING_INCENTIVE);
+        Dispenser dispenserImpl = new Dispenser(OLAS, TOKENOMICS, RETAINER);
         bytes memory initData = abi.encodeWithSelector(dispenserImpl.initialize.selector,
             TREASURY, address(this), uint256(1), uint256(10));
         DispenserProxy dispenserProxy = new DispenserProxy(address(dispenserImpl), initData);


### PR DESCRIPTION
Stacked on #313. Addresses the review comments on #309 and the follow-up cleanup discussed there.

## What changed

**Remove the `defaultMinStakingWeight` / `defaultMaxStakingIncentive` immutables and their claim-time fallback.**
The fallback filled a `StakingPoint` with these defaults when `minStakingWeight == 0 && maxStakingIncentive == 0`. On a live Tokenomics that combination is unreachable when `stakingFraction > 0`:
- `Tokenomics.changeStakingParams` rejects zero for both parameters, and
- at epoch settlement the values are inherited from the previous (non-zero) epoch when not re-requested.

So the fallback was dead code. The block collapses to a plain `continue` when `stakingFraction == 0`.

**Remove `Dispenser.changeStakingParams` (and its `StakingParamsUpdated` event).**
It only set `maxNumClaimingEpochs` / `maxNumStakingTargets`, which are now established once at `initialize()`. No deployment or proposal script calls it. The Dispenser is proxy-upgradeable, so a future implementation can reintroduce a setter if one is ever needed.
> Note: this makes `maxNumClaimingEpochs` / `maxNumStakingTargets` set-once at `initialize()` — there is no longer a runtime setter for them.

**Constructor is now `(olas, tokenomics, retainer)`** — `deploy_07a_dispenser.sh` and every Dispenser test updated accordingly.

**Misc:** bump `Dispenser` + `DispenserProxy` pragma to `0.8.30`; add the `DispenserProxy` co-author; trim the over-explanatory storage/immutable comments flagged in the #309 review.

## Tests
- Forge unit: `forge test --mc Dispenser` — 17/17.
- Forge fork (proxied claim path vs live mainnet): `StakingClaimForkETH` — 3/3.
- Hardhat: full `yarn test` suite green. `DispenserFixes` now sets the staking params explicitly (mirroring the live invariant); the removed `changeStakingParams` DAO-setter test is dropped; the input-bound `Overflow` checks are re-exercised via a dedicated small-bounds `(1,1)` dispenser instance.
- solhint / eslint clean (no new errors).

## Out of scope (flagged)
- `abis/*/Dispenser.json` + `docs/configuration.json` still reference a stale Dispenser ABI (already stale since the #309 proxy refactor — old 9-arg constructor). ABI regeneration is a release-artifact step, handled at redeploy time.
- `Vulnerabilities_list_tokenomics.md` unchanged — those entries come off only after the physical redeploy + rewiring.