### PR TITLE
refactor(Dispenser): make calculateStakingIncentives view; move effects to the claim path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,12 +57,14 @@ forge test -f $FORK_ETH_NODE_URL --mc LiquidityManagerObservationCardinalityGasE
 forge test -f $FORK_ETH_NODE_URL --mc UniswapPriceOracleETH -vvv
 forge test -f $FORK_ETH_NODE_URL --mc BuyBackBurnerUniswapETH -vvv
 forge test -f $FORK_ETH_NODE_URL --mc StakingClaimForkETH -vvv        # proxied Dispenser claim path vs live Tokenomics/Treasury
+forge test -f $FORK_ETH_NODE_URL --mc StakingL1ProcessorForkETH -vvv  # new Dispenser proxy vs real EthereumDepositProcessor (L1 migration leg)
 forge test -f $FORK_BASE_NODE_URL --mc LiquidityManagerBase -vvv      # Base
 forge test -f $FORK_BASE_NODE_URL --mc BalancerPriceOracleBase -vvv
 forge test -f $FORK_BASE_NODE_URL --mc BuyBackBurnerBalancerBase -vvv
 forge test -f $FORK_POLYGON_NODE_URL --mc BuyBackBurnerBalancerPolygon -vvv   # Polygon
 forge test -f $FORK_ARBITRUM_NODE_URL --mc BuyBackBurnerBalancerArbitrum -vvv  # Arbitrum
 forge test -f $FORK_OPTIMISM_NODE_URL --mc BuyBackBurnerTransferV3Optimism -vvv  # Optimism
+forge test -f $FORK_OPTIMISM_NODE_URL --mc StakingL2MigrateForkOP -vvv         # L2 target dispenser pause/migrate/withheld cutover (L2 migration leg)
 forge test -f https://forno.celo.org --mc LPSwapCeloForkTest -vvv             # Celo
 ```
 

--- a/contracts/Dispenser.sol
+++ b/contracts/Dispenser.sol
@@ -410,12 +410,14 @@ contract Dispenser {
         emit ImplementationUpdated(implementation);
     }
 
-    /// @dev Checkpoints specified staking target (nominee in Vote Weighting) and gets claimed epoch counters.
+    /// @dev Gets the claimable epoch counters for a nominee, bounded by the current and removal epochs.
+    /// @notice View only — it does NOT checkpoint the nominee in Vote Weighting (that is a separate
+    ///         checkpointNominee call in the claim/retain flow); "counters" here are the claim cursors.
     /// @param nomineeHash Hash of a Nominee(stakingTarget, chainId).
     /// @param numClaimedEpochs Specified number of claimed epochs.
     /// @return firstClaimedEpoch First claimed epoch number.
     /// @return lastClaimedEpoch Last claimed epoch number (not included in claiming).
-    function _checkpointNomineeAndGetClaimedEpochCounters(
+    function _getClaimedEpochCounters(
         bytes32 nomineeHash,
         uint256 numClaimedEpochs
     ) internal view returns (uint256 firstClaimedEpoch, uint256 lastClaimedEpoch) {
@@ -670,12 +672,24 @@ contract Dispenser {
                     revert WrongAccount(retainer);
                 }
 
+                // Checkpoint staking target nominee in the Vote Weighting contract before the (view) calculation
+                IVoteWeighting(voteWeighting).checkpointNominee(stakingTargets[i][j], chainIds[i]);
+
                 // Get the staking incentive to send as a deposit with, and the amount to return back to staking inflation
-                (uint256 stakingIncentive, uint256 returnAmount, uint256 lastClaimedEpoch, bytes32 nomineeHash) =
+                (uint256 stakingIncentive, uint256 returnAmount, uint256 lastClaimedEpoch, bytes32 nomineeHash,
+                    uint256[] memory zeroWeightEpochs) =
                     calculateStakingIncentives(numClaimedEpochs, chainIds[i], stakingTargets[i][j], bridgingDecimals);
 
                 // Write last claimed epoch counter to start claiming from the next time
                 mapLastClaimedStakingEpochs[nomineeHash] = lastClaimedEpoch;
+
+                // Mark zero-weight epochs refunded (amount already in returnAmount). Setting the flag here, before
+                // the next target's calculateStakingIncentives call, dedupes zero-weight epochs shared across targets
+                for (uint256 k = 0; k < zeroWeightEpochs.length; ++k) {
+                    if (zeroWeightEpochs[k] != 0) {
+                        mapZeroWeightEpochRefunded[zeroWeightEpochs[k]] = true;
+                    }
+                }
 
                 stakingIncentives[i][j] = stakingIncentive;
                 transferAmounts[i] += stakingIncentive;
@@ -807,9 +821,9 @@ contract Dispenser {
         mapLastClaimedStakingEpochs[nomineeHash] = ITokenomics(tokenomics).epochCounter();
 
         // Clear a possible removal epoch left from a previous nominee lifecycle: without this, a re-added
-        // nominee would permanently revert in _checkpointNomineeAndGetClaimedEpochCounters (the claim cursor
-        // just set above always satisfies firstClaimedEpoch >= epochRemoved). The Dispenser no longer relies
-        // on the upstream Vote Weighting enforcing "remove is final"
+        // nominee would permanently revert in _getClaimedEpochCounters (the claim cursor just set above always
+        // satisfies firstClaimedEpoch >= epochRemoved). The Dispenser no longer relies on the upstream Vote
+        // Weighting enforcing "remove is final"
         delete mapRemovedNomineeEpochs[nomineeHash];
 
         emit AddNomineeHash(nomineeHash);
@@ -923,20 +937,27 @@ contract Dispenser {
     /// @param chainId Chain Id.
     /// @param stakingTarget Staking target corresponding to the chain Id.
     /// @param bridgingDecimals Number of supported token decimals able to be transferred across the bridge.
+    /// @notice View only: the caller must checkpoint the nominee in Vote Weighting BEFORE calling this, and
+    ///         mark every returned zero-weight epoch as refunded (see `zeroWeightEpochs`). Because the
+    ///         function mutates nothing, a standalone call can never strand a zero-weight epoch's inflation.
     /// @return totalStakingIncentive Total staking incentive across all the claimed epochs.
-    /// @return totalReturnAmount Total return amount across all the claimed epochs.
+    /// @return totalReturnAmount Total return amount across all the claimed epochs (includes zero-weight epochs).
     /// @return lastClaimedEpoch Last claimed epoch number (not included in claiming).
     /// @return nomineeHash Hash of a Nominee(stakingTarget, chainId).
+    /// @return zeroWeightEpochs Sparse array over [firstClaimedEpoch, lastClaimedEpoch): a non-zero slot is a
+    ///         zero-total-weight epoch number the caller must set in `mapZeroWeightEpochRefunded` (epoch is
+    ///         never zero, so a zero slot means "not a zero-weight epoch"). Its incentive is in totalReturnAmount.
     function calculateStakingIncentives(
         uint256 numClaimedEpochs,
         uint256 chainId,
         bytes32 stakingTarget,
         uint256 bridgingDecimals
-    ) public returns (
+    ) public view returns (
         uint256 totalStakingIncentive,
         uint256 totalReturnAmount,
         uint256 lastClaimedEpoch,
-        bytes32 nomineeHash
+        bytes32 nomineeHash,
+        uint256[] memory zeroWeightEpochs
     ) {
         // Check for the correct chain Id
         if (chainId == 0) {
@@ -958,10 +979,10 @@ contract Dispenser {
 
         uint256 firstClaimedEpoch;
         (firstClaimedEpoch, lastClaimedEpoch) =
-            _checkpointNomineeAndGetClaimedEpochCounters(nomineeHash, numClaimedEpochs);
+            _getClaimedEpochCounters(nomineeHash, numClaimedEpochs);
 
-        // Checkpoint staking target nominee in the Vote Weighting contract
-        IVoteWeighting(voteWeighting).checkpointNominee(stakingTarget, chainId);
+        // Sparse zero-weight epoch record indexed by (j - firstClaimedEpoch); the caller sets the refunded flag
+        zeroWeightEpochs = new uint256[](lastClaimedEpoch - firstClaimedEpoch);
 
         // Traverse all the claimed epochs
         for (uint256 j = firstClaimedEpoch; j < lastClaimedEpoch; ++j) {
@@ -989,13 +1010,13 @@ contract Dispenser {
             (uint256 stakingWeight, uint256 totalWeightSum) =
                 IVoteWeighting(voteWeighting).nomineeRelativeWeight(stakingTarget, chainId, endTime);
 
-            // Check if the totalWeightSum is zero, then all staking incentives must be returned back to tokenomics
+            // Zero total vote weight: the whole epoch's staking incentive returns to inflation. Record the epoch
+            // so the caller sets mapZeroWeightEpochRefunded once (this view function cannot); the amount is folded
+            // into totalReturnAmount, which the caller refunds. Safe for batch: the caller sets the flag before the
+            // next target's call, so the mapZeroWeightEpochRefunded skip above dedupes shared zero-weight epochs.
             if (totalWeightSum == 0) {
-                // The one-way refunded flag and the actual refund are performed atomically in the same call:
-                // this function is public, and setting the flag while deferring the refund to the caller would
-                // let a standalone external call permanently mark the epoch refunded without any refund executed
-                mapZeroWeightEpochRefunded[j] = true;
-                ITokenomics(tokenomics).refundFromStaking(stakingPoint.stakingIncentive);
+                zeroWeightEpochs[j - firstClaimedEpoch] = j;
+                totalReturnAmount += stakingPoint.stakingIncentive;
                 continue;
             }
 
@@ -1096,12 +1117,23 @@ contract Dispenser {
         address depositProcessor = mapChainIdDepositProcessors[chainId];
         uint256 bridgingDecimals = IDepositProcessor(depositProcessor).getBridgingDecimals();
 
+        // Checkpoint staking target nominee in the Vote Weighting contract before the (view) calculation
+        IVoteWeighting(voteWeighting).checkpointNominee(stakingTarget, chainId);
+
         // Get the staking incentive to send as a deposit with, and the amount to return back to staking inflation
-        (uint256 stakingIncentive, uint256 returnAmount, uint256 lastClaimedEpoch, bytes32 nomineeHash) =
+        (uint256 stakingIncentive, uint256 returnAmount, uint256 lastClaimedEpoch, bytes32 nomineeHash,
+            uint256[] memory zeroWeightEpochs) =
             calculateStakingIncentives(numClaimedEpochs, chainId, stakingTarget, bridgingDecimals);
 
         // Write last claimed epoch counter to start claiming from the next time
         mapLastClaimedStakingEpochs[nomineeHash] = lastClaimedEpoch;
+
+        // Mark zero-weight epochs refunded (their incentive is already part of returnAmount)
+        for (uint256 i = 0; i < zeroWeightEpochs.length; ++i) {
+            if (zeroWeightEpochs[i] != 0) {
+                mapZeroWeightEpochRefunded[zeroWeightEpochs[i]] = true;
+            }
+        }
 
         // Refund returned amount back to tokenomics inflation
         if (returnAmount > 0) {
@@ -1251,7 +1283,7 @@ contract Dispenser {
 
         // Get first and last claimed epochs
         (uint256 firstClaimedEpoch, uint256 lastClaimedEpoch) =
-            _checkpointNomineeAndGetClaimedEpochCounters(retainerHash, maxNumClaimingEpochs);
+            _getClaimedEpochCounters(retainerHash, maxNumClaimingEpochs);
 
         // Checkpoint staking target nominee in the Vote Weighting contract
         IVoteWeighting(voteWeighting).checkpointNominee(retainer, block.chainid);

--- a/contracts/Dispenser.sol
+++ b/contracts/Dispenser.sol
@@ -786,9 +786,10 @@ contract Dispenser {
 
         // Change Vote Weighting contract address
         if (_voteWeighting != address(0)) {
-            // Swapping the Vote Weighting contract orphans the per-nominee claim cursors recorded under the
-            // previous nominee set: any staking incentives not yet claimed become unreachable. Require staking
-            // incentives to be paused first, so all outstanding claims are settled before the swap
+            // Swapping the Vote Weighting contract does NOT orphan the claim cursors themselves — they are keyed
+            // by keccak256(Nominee(target, chainId)), independent of the Vote Weighting instance. What becomes
+            // unreachable is any pending claim for a nominee that is not re-added to the new Vote Weighting.
+            // Require staking incentives to be paused first, so outstanding claims can be settled before the swap.
             Pause currentPause = paused;
             if (currentPause != Pause.StakingIncentivesPaused && currentPause != Pause.AllPaused) {
                 revert Unpaused();
@@ -844,6 +845,9 @@ contract Dispenser {
             revert Paused();
         }
 
+        // A newly added nominee starts claiming from the CURRENT epoch, so historical epochs are never traversed
+        // on this deployment. This greenfield-cursor property is what makes a fresh Dispenser safe against any
+        // pre-existing zero-staking-param epochs, and is the reason the default-param fallback could be dropped.
         mapLastClaimedStakingEpochs[nomineeHash] = ITokenomics(tokenomics).epochCounter();
 
         // Clear a possible removal epoch left from a previous nominee lifecycle: without this, a re-added
@@ -1026,6 +1030,12 @@ contract Dispenser {
             if (stakingPoint.stakingFraction == 0) {
                 continue;
             }
+
+            // Cross-contract invariant, load-bearing since the Dispenser dropped its default-param fallback:
+            // Tokenomics never settles a StakingPoint with stakingFraction > 0 and a zero maxStakingIncentive /
+            // minStakingWeight (changeStakingParams rejects zero and the epoch carry-forward preserves both). Were
+            // that ever violated, maxStakingIncentive == 0 clamps this epoch's incentive to zero (fully returned)
+            // and minStakingWeight == 0 disables the weight threshold — i.e. zero incentives, never over-payment.
 
             uint256 endTime = ITokenomics(tokenomics).getEpochEndTime(j);
 

--- a/contracts/Dispenser.sol
+++ b/contracts/Dispenser.sol
@@ -418,12 +418,14 @@ contract Dispenser {
         emit ImplementationUpdated(implementation);
     }
 
-    /// @dev Checkpoints specified staking target (nominee in Vote Weighting) and gets claimed epoch counters.
+    /// @dev Gets the claimable epoch counters for a nominee, bounded by the current and removal epochs.
+    /// @notice View only — it does NOT checkpoint the nominee in Vote Weighting (that is a separate
+    ///         checkpointNominee call in the claim/retain flow); "counters" here are the claim cursors.
     /// @param nomineeHash Hash of a Nominee(stakingTarget, chainId).
     /// @param numClaimedEpochs Specified number of claimed epochs.
     /// @return firstClaimedEpoch First claimed epoch number.
     /// @return lastClaimedEpoch Last claimed epoch number (not included in claiming).
-    function _checkpointNomineeAndGetClaimedEpochCounters(
+    function _getClaimedEpochCounters(
         bytes32 nomineeHash,
         uint256 numClaimedEpochs
     ) internal view returns (uint256 firstClaimedEpoch, uint256 lastClaimedEpoch) {
@@ -678,12 +680,24 @@ contract Dispenser {
                     revert WrongAccount(retainer);
                 }
 
+                // Checkpoint staking target nominee in the Vote Weighting contract before the (view) calculation
+                IVoteWeighting(voteWeighting).checkpointNominee(stakingTargets[i][j], chainIds[i]);
+
                 // Get the staking incentive to send as a deposit with, and the amount to return back to staking inflation
-                (uint256 stakingIncentive, uint256 returnAmount, uint256 lastClaimedEpoch, bytes32 nomineeHash) =
+                (uint256 stakingIncentive, uint256 returnAmount, uint256 lastClaimedEpoch, bytes32 nomineeHash,
+                    uint256[] memory zeroWeightEpochs) =
                     calculateStakingIncentives(numClaimedEpochs, chainIds[i], stakingTargets[i][j], bridgingDecimals);
 
                 // Write last claimed epoch counter to start claiming from the next time
                 mapLastClaimedStakingEpochs[nomineeHash] = lastClaimedEpoch;
+
+                // Mark zero-weight epochs refunded (amount already in returnAmount). Setting the flag here, before
+                // the next target's calculateStakingIncentives call, dedupes zero-weight epochs shared across targets
+                for (uint256 k = 0; k < zeroWeightEpochs.length; ++k) {
+                    if (zeroWeightEpochs[k] != 0) {
+                        mapZeroWeightEpochRefunded[zeroWeightEpochs[k]] = true;
+                    }
+                }
 
                 stakingIncentives[i][j] = stakingIncentive;
                 transferAmounts[i] += stakingIncentive;
@@ -815,9 +829,9 @@ contract Dispenser {
         mapLastClaimedStakingEpochs[nomineeHash] = ITokenomics(tokenomics).epochCounter();
 
         // Clear a possible removal epoch left from a previous nominee lifecycle: without this, a re-added
-        // nominee would permanently revert in _checkpointNomineeAndGetClaimedEpochCounters (the claim cursor
-        // just set above always satisfies firstClaimedEpoch >= epochRemoved). The Dispenser no longer relies
-        // on the upstream Vote Weighting enforcing "remove is final"
+        // nominee would permanently revert in _getClaimedEpochCounters (the claim cursor just set above always
+        // satisfies firstClaimedEpoch >= epochRemoved). The Dispenser no longer relies on the upstream Vote
+        // Weighting enforcing "remove is final"
         delete mapRemovedNomineeEpochs[nomineeHash];
 
         emit AddNomineeHash(nomineeHash);
@@ -931,20 +945,27 @@ contract Dispenser {
     /// @param chainId Chain Id.
     /// @param stakingTarget Staking target corresponding to the chain Id.
     /// @param bridgingDecimals Number of supported token decimals able to be transferred across the bridge.
+    /// @notice View only: the caller must checkpoint the nominee in Vote Weighting BEFORE calling this, and
+    ///         mark every returned zero-weight epoch as refunded (see `zeroWeightEpochs`). Because the
+    ///         function mutates nothing, a standalone call can never strand a zero-weight epoch's inflation.
     /// @return totalStakingIncentive Total staking incentive across all the claimed epochs.
-    /// @return totalReturnAmount Total return amount across all the claimed epochs.
+    /// @return totalReturnAmount Total return amount across all the claimed epochs (includes zero-weight epochs).
     /// @return lastClaimedEpoch Last claimed epoch number (not included in claiming).
     /// @return nomineeHash Hash of a Nominee(stakingTarget, chainId).
+    /// @return zeroWeightEpochs Sparse array over [firstClaimedEpoch, lastClaimedEpoch): a non-zero slot is a
+    ///         zero-total-weight epoch number the caller must set in `mapZeroWeightEpochRefunded` (epoch is
+    ///         never zero, so a zero slot means "not a zero-weight epoch"). Its incentive is in totalReturnAmount.
     function calculateStakingIncentives(
         uint256 numClaimedEpochs,
         uint256 chainId,
         bytes32 stakingTarget,
         uint256 bridgingDecimals
-    ) public returns (
+    ) public view returns (
         uint256 totalStakingIncentive,
         uint256 totalReturnAmount,
         uint256 lastClaimedEpoch,
-        bytes32 nomineeHash
+        bytes32 nomineeHash,
+        uint256[] memory zeroWeightEpochs
     ) {
         // Check for the correct chain Id
         if (chainId == 0) {
@@ -966,10 +987,10 @@ contract Dispenser {
 
         uint256 firstClaimedEpoch;
         (firstClaimedEpoch, lastClaimedEpoch) =
-            _checkpointNomineeAndGetClaimedEpochCounters(nomineeHash, numClaimedEpochs);
+            _getClaimedEpochCounters(nomineeHash, numClaimedEpochs);
 
-        // Checkpoint staking target nominee in the Vote Weighting contract
-        IVoteWeighting(voteWeighting).checkpointNominee(stakingTarget, chainId);
+        // Sparse zero-weight epoch record indexed by (j - firstClaimedEpoch); the caller sets the refunded flag
+        zeroWeightEpochs = new uint256[](lastClaimedEpoch - firstClaimedEpoch);
 
         // Traverse all the claimed epochs
         for (uint256 j = firstClaimedEpoch; j < lastClaimedEpoch; ++j) {
@@ -997,13 +1018,13 @@ contract Dispenser {
             (uint256 stakingWeight, uint256 totalWeightSum) =
                 IVoteWeighting(voteWeighting).nomineeRelativeWeight(stakingTarget, chainId, endTime);
 
-            // Check if the totalWeightSum is zero, then all staking incentives must be returned back to tokenomics
+            // Zero total vote weight: the whole epoch's staking incentive returns to inflation. Record the epoch
+            // so the caller sets mapZeroWeightEpochRefunded once (this view function cannot); the amount is folded
+            // into totalReturnAmount, which the caller refunds. Safe for batch: the caller sets the flag before the
+            // next target's call, so the mapZeroWeightEpochRefunded skip above dedupes shared zero-weight epochs.
             if (totalWeightSum == 0) {
-                // The one-way refunded flag and the actual refund are performed atomically in the same call:
-                // this function is public, and setting the flag while deferring the refund to the caller would
-                // let a standalone external call permanently mark the epoch refunded without any refund executed
-                mapZeroWeightEpochRefunded[j] = true;
-                ITokenomics(tokenomics).refundFromStaking(stakingPoint.stakingIncentive);
+                zeroWeightEpochs[j - firstClaimedEpoch] = j;
+                totalReturnAmount += stakingPoint.stakingIncentive;
                 continue;
             }
 
@@ -1104,12 +1125,23 @@ contract Dispenser {
         address depositProcessor = mapChainIdDepositProcessors[chainId];
         uint256 bridgingDecimals = IDepositProcessor(depositProcessor).getBridgingDecimals();
 
+        // Checkpoint staking target nominee in the Vote Weighting contract before the (view) calculation
+        IVoteWeighting(voteWeighting).checkpointNominee(stakingTarget, chainId);
+
         // Get the staking incentive to send as a deposit with, and the amount to return back to staking inflation
-        (uint256 stakingIncentive, uint256 returnAmount, uint256 lastClaimedEpoch, bytes32 nomineeHash) =
+        (uint256 stakingIncentive, uint256 returnAmount, uint256 lastClaimedEpoch, bytes32 nomineeHash,
+            uint256[] memory zeroWeightEpochs) =
             calculateStakingIncentives(numClaimedEpochs, chainId, stakingTarget, bridgingDecimals);
 
         // Write last claimed epoch counter to start claiming from the next time
         mapLastClaimedStakingEpochs[nomineeHash] = lastClaimedEpoch;
+
+        // Mark zero-weight epochs refunded (their incentive is already part of returnAmount)
+        for (uint256 i = 0; i < zeroWeightEpochs.length; ++i) {
+            if (zeroWeightEpochs[i] != 0) {
+                mapZeroWeightEpochRefunded[zeroWeightEpochs[i]] = true;
+            }
+        }
 
         // Refund returned amount back to tokenomics inflation
         if (returnAmount > 0) {
@@ -1259,7 +1291,7 @@ contract Dispenser {
 
         // Get first and last claimed epochs
         (uint256 firstClaimedEpoch, uint256 lastClaimedEpoch) =
-            _checkpointNomineeAndGetClaimedEpochCounters(retainerHash, maxNumClaimingEpochs);
+            _getClaimedEpochCounters(retainerHash, maxNumClaimingEpochs);
 
         // Checkpoint staking target nominee in the Vote Weighting contract
         IVoteWeighting(voteWeighting).checkpointNominee(retainer, block.chainid);

--- a/contracts/Dispenser.sol
+++ b/contracts/Dispenser.sol
@@ -418,6 +418,20 @@ contract Dispenser {
         emit ImplementationUpdated(implementation);
     }
 
+    /// @dev Reverts if a staking target nominee is not claimable (was never added to Vote Weighting).
+    /// @notice Guards the checkpointNominee call in the claim paths: on the real Vote Weighting,
+    ///         checkpointNominee reverts (NomineeDoesNotExist) for an unregistered nominee, so this makes the
+    ///         Dispenser's own ZeroValue the authoritative not-claimable error and ensures checkpointNominee is
+    ///         only ever called for a live nominee. Mirrors the first check in _getClaimedEpochCounters.
+    /// @param stakingTarget Staking target address in bytes32 form.
+    /// @param chainId Chain Id.
+    function _requireClaimableNominee(bytes32 stakingTarget, uint256 chainId) internal view {
+        bytes32 nomineeHash = keccak256(abi.encode(IVoteWeighting.Nominee(stakingTarget, chainId)));
+        if (mapLastClaimedStakingEpochs[nomineeHash] == 0) {
+            revert ZeroValue();
+        }
+    }
+
     /// @dev Gets the claimable epoch counters for a nominee, bounded by the current and removal epochs.
     /// @notice View only — it does NOT checkpoint the nominee in Vote Weighting (that is a separate
     ///         checkpointNominee call in the claim/retain flow); "counters" here are the claim cursors.
@@ -679,6 +693,10 @@ contract Dispenser {
                 if (stakingTargets[i][j] == retainer) {
                     revert WrongAccount(retainer);
                 }
+
+                // Guard claimability before checkpointing (see claimStakingIncentives): keeps ZeroValue the
+                // authoritative not-claimable error and only checkpoints a live nominee
+                _requireClaimableNominee(stakingTargets[i][j], chainIds[i]);
 
                 // Checkpoint staking target nominee in the Vote Weighting contract before the (view) calculation
                 IVoteWeighting(voteWeighting).checkpointNominee(stakingTargets[i][j], chainIds[i]);
@@ -1124,6 +1142,12 @@ contract Dispenser {
         // Get deposit processor bridging decimals corresponding to a chain Id
         address depositProcessor = mapChainIdDepositProcessors[chainId];
         uint256 bridgingDecimals = IDepositProcessor(depositProcessor).getBridgingDecimals();
+
+        // Ensure the nominee is claimable before checkpointing it. On the real Vote Weighting, checkpointNominee
+        // reverts (NomineeDoesNotExist) for a nominee that was never added, so guard with the Dispenser's own
+        // cursor first: this keeps ZeroValue the authoritative "not claimable" error and only ever checkpoints a
+        // live nominee (mirrors the retain() ordering, where the cursor check precedes the checkpoint)
+        _requireClaimableNominee(stakingTarget, chainId);
 
         // Checkpoint staking target nominee in the Vote Weighting contract before the (view) calculation
         IVoteWeighting(voteWeighting).checkpointNominee(stakingTarget, chainId);

--- a/contracts/test/MockVoteWeighting.sol
+++ b/contracts/test/MockVoteWeighting.sol
@@ -12,6 +12,9 @@ struct Nominee {
     uint256 chainId;
 }
 
+/// @dev Nominee does not exist (mirrors the real Vote Weighting error surface).
+error NomineeDoesNotExist(bytes32 account, uint256 chainId);
+
 /// @dev Mocking contract of vote weighting.
 contract MockVoteWeighting {
     address public immutable dispenser;
@@ -30,10 +33,15 @@ contract MockVoteWeighting {
     }
 
     /// @dev Checkpoint to fill data for both a specific nominee and common for all nominees.
-    /// @notice No-op for an unregistered nominee, mirroring the real Curve-style gauge controller (it
-    ///         operates on zero-initialized weight points and does not revert). The authoritative
-    ///         "exists for claiming" gate is the Dispenser's own mapLastClaimedStakingEpochs check.
-    function checkpointNominee(bytes32 account, uint256 chainId) external view {}
+    /// @notice Mirrors the real Vote Weighting: checkpointNominee -> _getWeight reverts NomineeDoesNotExist for a
+    ///         nominee that was never added. The Dispenser guards this call with its own claimable-cursor check
+    ///         (_requireClaimableNominee), so this revert path is only reached if the two ever disagree.
+    function checkpointNominee(bytes32 account, uint256 chainId) external view {
+        bytes32 nomineeHash = keccak256(abi.encode(Nominee(account, chainId)));
+        if (mapNomineeIds[nomineeHash] == 0) {
+            revert NomineeDoesNotExist(account, chainId);
+        }
+    }
 
     /// @dev Set staking weight.
     function setNomineeRelativeWeight(address account, uint256 chainId, uint256 weight) external {

--- a/contracts/test/MockVoteWeighting.sol
+++ b/contracts/test/MockVoteWeighting.sol
@@ -30,15 +30,10 @@ contract MockVoteWeighting {
     }
 
     /// @dev Checkpoint to fill data for both a specific nominee and common for all nominees.
-    /// @param account Address of the nominee.
-    /// @param chainId Chain Id.
-    function checkpointNominee(bytes32 account, uint256 chainId) external view {
-        Nominee memory nominee = Nominee(account, chainId);
-        bytes32 nomineeHash = keccak256(abi.encode(nominee));
-        if (mapNomineeIds[nomineeHash] == 0) {
-            revert();
-        }
-    }
+    /// @notice No-op for an unregistered nominee, mirroring the real Curve-style gauge controller (it
+    ///         operates on zero-initialized weight points and does not revert). The authoritative
+    ///         "exists for claiming" gate is the Dispenser's own mapLastClaimedStakingEpochs check.
+    function checkpointNominee(bytes32 account, uint256 chainId) external view {}
 
     /// @dev Set staking weight.
     function setNomineeRelativeWeight(address account, uint256 chainId, uint256 weight) external {

--- a/test/DispenserFixes.t.sol
+++ b/test/DispenserFixes.t.sol
@@ -36,8 +36,8 @@ contract MockDepositProcessor {
 }
 
 /// @dev Regression tests for the Dispenser vulnerability-list fixes (each fails on the pre-fix code):
-///      #12 zero-weight epoch refund is atomic with its one-way flag (public calculateStakingIncentives
-///          can no longer permanently strand the refund);
+///      #12 calculateStakingIncentives is view — a standalone call mutates nothing (cannot strand a
+///          zero-weight epoch's refund); the claim path refunds it exactly once and never double-refunds;
 ///      #9  the withheld-covered portion of claimed incentives is returned to staking inflation
 ///          (single and batch claim paths);
 ///      #25 addNominee clears mapRemovedNomineeEpochs so a removed-then-re-added nominee is claimable;
@@ -140,15 +140,25 @@ contract DispenserFixesTest is Test {
         return keccak256(abi.encode(_targetBytes32(), CHAIN_ID));
     }
 
+    /// @dev True if `value` appears in `arr` (used to check the sparse zeroWeightEpochs return).
+    function _arrayContains(uint256[] memory arr, uint256 value) internal pure returns (bool) {
+        for (uint256 i = 0; i < arr.length; ++i) {
+            if (arr[i] == value) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     // -----------------------------------------------------------------------
     // #12 — zero-weight epoch refund is atomic with the one-way flag
     // -----------------------------------------------------------------------
 
-    /// @dev A standalone external call to the public calculateStakingIncentives on a zero-total-weight epoch
-    ///      must execute the refund in the same transaction it sets mapZeroWeightEpochRefunded. On the pre-fix
-    ///      code the flag was set but the refund was left to the caller, permanently stranding the epoch's
-    ///      staking inflation.
-    function test_fix12_standaloneCalculate_zeroWeight_refundsAtomically() public {
+    /// @dev calculateStakingIncentives is view: a standalone call on a zero-total-weight epoch mutates nothing
+    ///      (it reports the epoch as returnable but neither sets mapZeroWeightEpochRefunded nor refunds), so it
+    ///      can never strand the epoch's inflation. The refund happens exactly once via the claim path, and a
+    ///      subsequent claim must not refund it again.
+    function test_fix12_viewCalculate_zeroWeight_refundsOnceViaClaim() public {
         // Nominate the target; no votes are ever cast, so nomineeRelativeWeight returns (0, 0)
         vw.addNominee(STAKING_TARGET, CHAIN_ID);
 
@@ -164,21 +174,86 @@ contract DispenserFixesTest is Test {
         uint256 currentEpoch = tokenomics.epochCounter();
         uint256 potBefore = _stakingIncentiveOf(currentEpoch);
 
-        // Standalone state-mutating call by an arbitrary account (NOT via the claim path)
+        // Standalone view call by an arbitrary account (NOT via the claim path): reports the zero-weight epoch,
+        // mutates nothing
         vm.prank(address(0xA77ACC));
-        dispenser.calculateStakingIncentives(10, CHAIN_ID, _targetBytes32(), 18);
+        (, uint256 returnAmount, , , uint256[] memory zeroWeightEpochs) =
+            dispenser.calculateStakingIncentives(10, CHAIN_ID, _targetBytes32(), 18);
+        assertEq(returnAmount, epochIncentive, "zero-weight incentive reported as returnable");
+        assertTrue(_arrayContains(zeroWeightEpochs, claimableEpoch), "zero-weight epoch reported");
+        // The view call left state untouched: flag unset and the staking pot unchanged
+        assertFalse(dispenser.mapZeroWeightEpochRefunded(claimableEpoch), "view call must not set the flag");
+        assertEq(_stakingIncentiveOf(currentEpoch), potBefore, "view call must not refund");
 
-        // The one-way flag is set...
-        assertTrue(dispenser.mapZeroWeightEpochRefunded(claimableEpoch), "zero-weight flag must be set");
-
-        // ...and the refund happened in the same tx: the epoch's incentive is back in the staking pot
-        uint256 potAfter = _stakingIncentiveOf(currentEpoch);
-        assertEq(potAfter - potBefore, epochIncentive, "flagged epoch incentive must be refunded atomically");
-
-        // A subsequent claim skips the refunded epoch and must not refund it again
+        // The claim path refunds the zero-weight epoch exactly once and sets the flag
         dispenser.claimStakingIncentives(10, CHAIN_ID, _targetBytes32(), "");
-        uint256 potFinal = _stakingIncentiveOf(currentEpoch);
-        assertEq(potFinal, potAfter, "no double refund on the claim path");
+        assertTrue(dispenser.mapZeroWeightEpochRefunded(claimableEpoch), "flag set on claim");
+        uint256 potAfter = _stakingIncentiveOf(currentEpoch);
+        assertEq(potAfter - potBefore, epochIncentive, "zero-weight incentive refunded once");
+    }
+
+    /// @dev Cross-transaction dedup: a second target claiming the SAME zero-weight epoch in a later tx must not
+    ///      refund it again — the persisted mapZeroWeightEpochRefunded flag makes the (view) calculation skip it.
+    function test_fix12_separateClaims_zeroWeight_noDoubleRefund() public {
+        address target2 = address(0x57A7); // fresh nominee, no votes -> shares the zero-weight epoch
+        vw.addNominee(STAKING_TARGET, CHAIN_ID);
+        vw.addNominee(target2, CHAIN_ID);
+
+        _advanceEpoch();
+        _advanceEpoch();
+
+        uint256 claimableEpoch = tokenomics.epochCounter() - 1;
+        uint256 epochIncentive = _stakingIncentiveOf(claimableEpoch);
+        uint256 currentEpoch = tokenomics.epochCounter();
+        uint256 potBefore = _stakingIncentiveOf(currentEpoch);
+
+        // First target claim (tx 1): refunds the zero-weight epoch once and sets the flag
+        dispenser.claimStakingIncentives(10, CHAIN_ID, _targetBytes32(), "");
+        uint256 potAfterFirst = _stakingIncentiveOf(currentEpoch);
+        assertEq(potAfterFirst - potBefore, epochIncentive, "first claim refunds the epoch once");
+        assertTrue(dispenser.mapZeroWeightEpochRefunded(claimableEpoch), "flag set");
+
+        // Second target claim (tx 2) for the same epoch: flag already set -> no additional refund
+        dispenser.claimStakingIncentives(10, CHAIN_ID, bytes32(uint256(uint160(target2))), "");
+        assertEq(_stakingIncentiveOf(currentEpoch), potAfterFirst, "no double refund across separate claims");
+    }
+
+    /// @dev Two targets share the same zero-total-weight epoch in a single batch claim. Zero-weight is a
+    ///      property of the epoch, so both targets would each want to refund its full incentive. The dispenser
+    ///      sets mapZeroWeightEpochRefunded for the first target before the second target's (view) calculation,
+    ///      so the epoch's inflation is refunded exactly once for the batch, not once per target.
+    function test_fix12_batchZeroWeight_dedupRefundsOnce() public {
+        // Two nominees on the same chain, neither ever voted for -> shared zero-total-weight epochs
+        address target2 = address(0x57A7); // strictly greater than STAKING_TARGET (0x57A6) for ascending order
+        vw.addNominee(STAKING_TARGET, CHAIN_ID);
+        vw.addNominee(target2, CHAIN_ID);
+
+        _advanceEpoch();
+        _advanceEpoch();
+
+        uint256 claimableEpoch = tokenomics.epochCounter() - 1;
+        uint256 epochIncentive = _stakingIncentiveOf(claimableEpoch);
+        assertGt(epochIncentive, 0, "settled epoch must carry staking incentive");
+
+        uint256 currentEpoch = tokenomics.epochCounter();
+        uint256 potBefore = _stakingIncentiveOf(currentEpoch);
+
+        // Single-chain batch claim over both targets (ascending order required)
+        uint256[] memory chainIds = new uint256[](1);
+        chainIds[0] = CHAIN_ID;
+        bytes32[][] memory stakingTargets = new bytes32[][](1);
+        stakingTargets[0] = new bytes32[](2);
+        stakingTargets[0][0] = _targetBytes32();
+        stakingTargets[0][1] = bytes32(uint256(uint160(target2)));
+        bytes[] memory bridgePayloads = new bytes[](1);
+        uint256[] memory valueAmounts = new uint256[](1);
+
+        dispenser.claimStakingIncentivesBatch(10, chainIds, stakingTargets, bridgePayloads, valueAmounts);
+
+        // The shared zero-weight epoch is refunded once for the whole batch, not once per target
+        assertTrue(dispenser.mapZeroWeightEpochRefunded(claimableEpoch), "flag set once");
+        uint256 potAfter = _stakingIncentiveOf(currentEpoch);
+        assertEq(potAfter - potBefore, epochIncentive, "zero-weight epoch refunded exactly once for the batch");
     }
 
     // -----------------------------------------------------------------------

--- a/test/DispenserFixes.t.sol
+++ b/test/DispenserFixes.t.sol
@@ -396,4 +396,19 @@ contract DispenserFixesTest is Test {
         vm.expectRevert(Unpaused.selector);
         dispenser.changeManagers(address(0), newVW);
     }
+
+    // A claim for a never-added nominee must revert ZeroValue from the Dispenser's own claimable-cursor guard,
+    // BEFORE checkpointNominee (which reverts NomineeDoesNotExist on the real Vote Weighting). This locks in the
+    // guard ordering: were the checkpoint to run first, this claim would surface NomineeDoesNotExist instead.
+    function test_claim_neverAddedNominee_revertsZeroValueBeforeCheckpoint() public {
+        bytes32 unregistered = bytes32(uint256(uint160(address(0x9999))));
+
+        // The mock faithfully mirrors the real Vote Weighting: checkpointing an unregistered nominee reverts
+        vm.expectRevert(abi.encodeWithSignature("NomineeDoesNotExist(bytes32,uint256)", unregistered, CHAIN_ID));
+        vw.checkpointNominee(unregistered, CHAIN_ID);
+
+        // Yet the claim path reverts ZeroValue (the guard fires first), not NomineeDoesNotExist
+        vm.expectRevert(abi.encodeWithSignature("ZeroValue()"));
+        dispenser.claimStakingIncentives(10, CHAIN_ID, unregistered, "");
+    }
 }

--- a/test/DispenserProxy.t.sol
+++ b/test/DispenserProxy.t.sol
@@ -95,6 +95,32 @@ contract DispenserProxyTest is Test {
         assertEq(proxied.voteWeighting(), VOTE_WEIGHTING, "voteWeighting wired");
     }
 
+    /// @dev Merged-state interaction of the zero-VW initialize (allow zero) and the go-live guard: a fresh proxy
+    ///      with voteWeighting == 0 cannot be brought live until Vote Weighting is wired. This is barrier 1 (the
+    ///      setPauseState guard); barrier 2 is _requireClaimableNominee returning a clean ZeroValue on a claim
+    ///      (covered in DispenserFixes.test_claim_neverAddedNominee_revertsZeroValueBeforeCheckpoint).
+    function test_setPauseState_requiresVoteWeighting_beforeGoLive() public {
+        Dispenser master = new Dispenser(OLAS, TOKENOMICS, RETAINER);
+        bytes memory initData = abi.encodeWithSelector(Dispenser.initialize.selector,
+            TREASURY, address(0), 10, 20);
+        Dispenser proxied = Dispenser(address(new DispenserProxy(address(master), initData)));
+
+        // Cannot let staking incentives go live while voteWeighting is unset (both staking-active states)
+        vm.expectRevert(ZeroAddress.selector);
+        proxied.setPauseState(Dispenser.Pause.Unpaused);
+        vm.expectRevert(ZeroAddress.selector);
+        proxied.setPauseState(Dispenser.Pause.DevIncentivesPaused);
+
+        // Re-pausing transitions stay allowed with a zero Vote Weighting
+        proxied.setPauseState(Dispenser.Pause.AllPaused);
+        proxied.setPauseState(Dispenser.Pause.StakingIncentivesPaused);
+
+        // Once Vote Weighting is wired (while paused), going live is permitted
+        proxied.changeManagers(address(0), VOTE_WEIGHTING);
+        proxied.setPauseState(Dispenser.Pause.Unpaused);
+        assertEq(uint256(proxied.paused()), uint256(Dispenser.Pause.Unpaused), "live after wiring");
+    }
+
     function test_initialize_proxyReinit_reverts() public {
         vm.expectRevert(AlreadyInitialized.selector);
         dispenser.initialize(TREASURY, VOTE_WEIGHTING, 10, 20);

--- a/test/StakingL1ProcessorForkETH.t.sol
+++ b/test/StakingL1ProcessorForkETH.t.sol
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Test} from "forge-std/Test.sol";
+import {Dispenser} from "../contracts/Dispenser.sol";
+import {DispenserProxy} from "../contracts/proxies/DispenserProxy.sol";
+import {EthereumDepositProcessor} from "../contracts/staking/EthereumDepositProcessor.sol";
+
+/// @dev Ethereum-mainnet fork test of the migration's L1 leg: the NEW proxy-based Dispenser wired to a
+///      freshly-deployed, REAL `EthereumDepositProcessor` (not the in-test stub used by StakingClaimForkETH).
+///
+///      What this uniquely proves for the redeploy (runbook §4 "hard immutable couplings" / §5 in-scope
+///      processors / §6 Phase 2 & 4):
+///        - `EthereumDepositProcessor.dispenser` is `immutable`, so a new Dispenser address forces a new
+///          processor. This deploys the processor with `dispenser = newDispenserProxy` and shows the
+///          `msg.sender == dispenser` gate authenticates the new proxy (and rejects anyone else) — the exact
+///          coupling that makes the processor part of the cascade.
+///        - the money-path is real end-to-end on L1: claim -> live Treasury mints real OLAS -> Dispenser
+///          forwards it to the new processor -> processor `approve` + `IStaking.deposit` moves it into the
+///          staking target, with the epoch cap refunded to live Tokenomics inflation and the processor-level
+///          emissions cap refunded to the Timelock.
+///
+///      Only the registries layer below the processor is stubbed (staking factory + staking instance) — the
+///      same philosophy as StakingClaimForkETH stubbing Vote Weighting / the L2 processor: every Tokenomics /
+///      Treasury / OLAS movement is against live mainnet state.
+///
+///      The contract name avoids the "Dispenser"/"Treasury"/"Depository" substrings so CI's fork-less
+///      `forge test --mc Dispenser|Treasury|Depository` allowlist does not pick it up and run it without a fork.
+///
+///      Run: forge test -f $FORK_ETH_NODE_URL --mc StakingL1ProcessorForkETH -vvv
+
+interface ITokenomicsForkL1 {
+    function epochLen() external view returns (uint256);
+    function epochCounter() external view returns (uint32);
+    function dispenser() external view returns (address);
+    function checkpoint() external;
+    function changeManagers(address treasury, address depository, address dispenser) external;
+    function mapEpochStakingPoints(uint256 epoch) external view
+        returns (uint96 stakingIncentive, uint96 maxStakingIncentive, uint16 minStakingWeight, uint8 stakingFraction);
+}
+
+interface ITreasuryForkL1 {
+    function changeManagers(address tokenomics, address depository, address dispenser) external;
+}
+
+interface IOLASForkL1 {
+    function balanceOf(address account) external view returns (uint256);
+    function totalSupply() external view returns (uint256);
+}
+
+/// @dev Stand-in Vote Weighting (mirrors StakingClaimForkETH): decouples nominee weight from the total sum so
+///      the epoch cap can be driven deterministically; mirrors the dispenser coupling (addNominee callback,
+///      checkpointNominee, nomineeRelativeWeight).
+contract ForkVoteWeightingL1 {
+    struct Nominee {
+        bytes32 account;
+        uint256 chainId;
+    }
+
+    address public immutable dispenser;
+    mapping(bytes32 => bool) public exists;
+    mapping(bytes32 => uint256) public relativeWeights;
+    mapping(bytes32 => uint256) public weightSums;
+
+    constructor(address _dispenser) {
+        dispenser = _dispenser;
+    }
+
+    function _hash(bytes32 account, uint256 chainId) internal pure returns (bytes32) {
+        return keccak256(abi.encode(Nominee(account, chainId)));
+    }
+
+    function addNominee(address account, uint256 chainId) external {
+        bytes32 nomineeHash = _hash(bytes32(uint256(uint160(account))), chainId);
+        exists[nomineeHash] = true;
+        Dispenser(dispenser).addNominee(nomineeHash);
+    }
+
+    function setWeights(address account, uint256 chainId, uint256 relativeWeight, uint256 weightSum) external {
+        bytes32 nomineeHash = _hash(bytes32(uint256(uint160(account))), chainId);
+        relativeWeights[nomineeHash] = relativeWeight;
+        weightSums[nomineeHash] = weightSum;
+    }
+
+    function checkpointNominee(bytes32 account, uint256 chainId) external view {
+        if (!exists[_hash(account, chainId)]) {
+            revert();
+        }
+    }
+
+    function nomineeRelativeWeight(bytes32 account, uint256 chainId, uint256) external view returns (uint256, uint256) {
+        bytes32 nomineeHash = _hash(account, chainId);
+        return (relativeWeights[nomineeHash], weightSums[nomineeHash]);
+    }
+}
+
+/// @dev Stand-in staking proxy factory: the emissions limit the processor caps a deposit at. Deterministic so
+///      both the "under cap" (full deposit) and "over cap" (processor refunds to Timelock) branches are testable.
+contract MockStakingFactoryL1 {
+    uint256 public emissionsLimit;
+
+    function setEmissionsLimit(uint256 limit) external {
+        emissionsLimit = limit;
+    }
+
+    function verifyInstanceAndGetEmissionsAmount(address) external view returns (uint256) {
+        return emissionsLimit;
+    }
+}
+
+/// @dev Stand-in staking instance: pulls the approved OLAS in on deposit, exactly as a real staking contract does.
+contract MockStakingInstanceL1 {
+    address public immutable olas;
+    uint256 public deposited;
+
+    constructor(address _olas) {
+        olas = _olas;
+    }
+
+    function deposit(uint256 amount) external {
+        (bool success, ) = olas.call(
+            abi.encodeWithSignature("transferFrom(address,address,uint256)", msg.sender, address(this), amount));
+        require(success, "transferFrom failed");
+        deposited += amount;
+    }
+}
+
+contract StakingL1ProcessorForkETH is Test {
+    // Ethereum mainnet addresses
+    address internal constant OLAS = 0x0001A500A6B18995B03f44bb040A5fFc28E45CB0;
+    address internal constant TOKENOMICS = 0xc096362fa6f4A4B1a9ea68b1043416f3381ce300;
+    address internal constant TREASURY = 0xa0DA53447C0f6C4987964d8463da7e6628B30f82;
+    address internal constant TIMELOCK = 0x3C1fF68f5aa342D296d4DEe4Bb1cACCA912D95fE;
+
+    // Dispenser implementation immutable
+    bytes32 internal constant RETAINER = bytes32(uint256(0xdEaD));
+
+    // Ethereum L1 staking rides on chain Id == 1 in production (EthereumDepositProcessor is the L1-only leg)
+    uint256 internal constant CHAIN_ID = 1;
+
+    Dispenser internal dispenser;
+    ForkVoteWeightingL1 internal vw;
+    EthereumDepositProcessor internal processor;
+    MockStakingFactoryL1 internal stakingFactory;
+    MockStakingInstanceL1 internal stakingInstance;
+    uint256 internal epochLen;
+
+    function setUp() public {
+        epochLen = ITokenomicsForkL1(TOKENOMICS).epochLen();
+
+        // New Dispenser implementation against the LIVE Tokenomics proxy, then the proxy (Vote Weighting is a
+        // placeholder set after the proxy exists, under the initial pause).
+        Dispenser dispenserImpl = new Dispenser(OLAS, TOKENOMICS, RETAINER);
+        bytes memory initData = abi.encodeWithSelector(dispenserImpl.initialize.selector,
+            TREASURY, address(this), uint256(1), uint256(10));
+        DispenserProxy dispenserProxy = new DispenserProxy(address(dispenserImpl), initData);
+        dispenser = Dispenser(address(dispenserProxy));
+
+        // Stand-in Vote Weighting over the new proxy; swap it in while paused (#8 guard)
+        vw = new ForkVoteWeightingL1(address(dispenser));
+        dispenser.changeManagers(address(0), address(vw));
+
+        // Registries layer below the processor (stubbed): factory returns the emissions cap, instance pulls OLAS
+        stakingFactory = new MockStakingFactoryL1();
+        stakingInstance = new MockStakingInstanceL1(OLAS);
+
+        // The REAL L1 deposit processor, deployed against the NEW dispenser proxy (the immutable coupling)
+        processor = new EthereumDepositProcessor(OLAS, address(dispenser), address(stakingFactory), TIMELOCK);
+
+        address[] memory processors = new address[](1);
+        processors[0] = address(processor);
+        uint256[] memory chainIds = new uint256[](1);
+        chainIds[0] = CHAIN_ID;
+        dispenser.setDepositProcessorChainIds(processors, chainIds);
+
+        // Migration wiring: repoint the LIVE Treasury and Tokenomics at the new dispenser (Timelock-owned)
+        vm.startPrank(TIMELOCK);
+        ITreasuryForkL1(TREASURY).changeManagers(address(0), address(0), address(dispenser));
+        ITokenomicsForkL1(TOKENOMICS).changeManagers(address(0), address(0), address(dispenser));
+        vm.stopPrank();
+
+        // Go live and register the staking instance as a fresh nominee (records the claim cursor)
+        dispenser.setPauseState(Dispenser.Pause.Unpaused);
+        vw.addNominee(address(stakingInstance), CHAIN_ID);
+        vw.setWeights(address(stakingInstance), CHAIN_ID, 1e18, 1e30);
+    }
+
+    function _targetBytes32() internal view returns (bytes32) {
+        return bytes32(uint256(uint160(address(stakingInstance))));
+    }
+
+    function _stakingIncentiveOf(uint256 epoch) internal view returns (uint256 amount) {
+        (amount, , , ) = ITokenomicsForkL1(TOKENOMICS).mapEpochStakingPoints(epoch);
+    }
+
+    function _maxStakingIncentiveOf(uint256 epoch) internal view returns (uint256 amount) {
+        (, amount, , ) = ITokenomicsForkL1(TOKENOMICS).mapEpochStakingPoints(epoch);
+    }
+
+    /// @dev Settles the current epoch on the live Tokenomics so it carries a staking incentive to claim.
+    function _advanceEpoch() internal {
+        vm.warp(block.timestamp + epochLen + 10);
+        vm.roll(block.number + 1);
+        ITokenomicsForkL1(TOKENOMICS).checkpoint();
+    }
+
+    /// @dev Returns the amount the Dispenser mints & forwards to the processor for the last settled epoch
+    ///      (the epoch incentive capped by the per-epoch max).
+    function _expectedForwarded() internal view returns (uint256 forwarded, uint256 epochReturn) {
+        uint256 claimableEpoch = ITokenomicsForkL1(TOKENOMICS).epochCounter() - 1;
+        uint256 epochIncentive = _stakingIncentiveOf(claimableEpoch);
+        uint256 maxInc = _maxStakingIncentiveOf(claimableEpoch);
+        require(epochIncentive > 0, "settled epoch must carry an incentive");
+        forwarded = epochIncentive < maxInc ? epochIncentive : maxInc;
+        epochReturn = epochIncentive - forwarded;
+    }
+
+    // -----------------------------------------------------------------------
+    // The new-processor <-> new-dispenser coupling
+    // -----------------------------------------------------------------------
+
+    function test_processorBoundToNewDispenser_authGate() public {
+        // The immutable that forces the processor redeploy points at the new proxy
+        assertEq(processor.dispenser(), address(dispenser), "processor.dispenser == new proxy");
+
+        // Only the wired dispenser can drive it
+        vm.prank(address(0xBAD));
+        vm.expectRevert();
+        processor.sendMessage(address(stakingInstance), 1 ether, "", 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // Full distribution: live mint -> new processor -> real deposit (under the emissions cap)
+    // -----------------------------------------------------------------------
+
+    function test_claimThroughRealProcessor_depositsIntoTarget() public {
+        _advanceEpoch();
+        (uint256 forwarded, uint256 epochReturn) = _expectedForwarded();
+
+        // Emissions cap comfortably above the forwarded amount -> the processor deposits all of it, no refund
+        stakingFactory.setEmissionsLimit(forwarded + 1 ether);
+
+        uint256 currentEpoch = ITokenomicsForkL1(TOKENOMICS).epochCounter();
+        uint256 potBefore = _stakingIncentiveOf(currentEpoch);
+        uint256 supplyBefore = IOLASForkL1(OLAS).totalSupply();
+        uint256 timelockBefore = IOLASForkL1(OLAS).balanceOf(TIMELOCK);
+
+        dispenser.claimStakingIncentives(1, CHAIN_ID, _targetBytes32(), "");
+
+        // Real OLAS was minted by the live Treasury and ended up staked in the target via the processor
+        assertEq(IOLASForkL1(OLAS).totalSupply() - supplyBefore, forwarded, "totalSupply grew by the mint");
+        assertEq(stakingInstance.deposited(), forwarded, "full forwarded amount deposited into the target");
+        assertEq(IOLASForkL1(OLAS).balanceOf(address(processor)), 0, "processor holds no residual OLAS");
+        assertEq(IOLASForkL1(OLAS).balanceOf(TIMELOCK), timelockBefore, "no processor-level refund under the cap");
+
+        // The per-epoch cap remainder is refunded to the live staking inflation
+        assertEq(_stakingIncentiveOf(currentEpoch) - potBefore, epochReturn, "capped remainder refunded to inflation");
+    }
+
+    // -----------------------------------------------------------------------
+    // Processor-level emissions cap: excess above the target's limit refunds to the Timelock
+    // -----------------------------------------------------------------------
+
+    function test_claimThroughRealProcessor_emissionsCapRefundsToTimelock() public {
+        _advanceEpoch();
+        (uint256 forwarded, ) = _expectedForwarded();
+
+        // Emissions cap below the forwarded amount -> the processor deposits the cap and refunds the excess
+        uint256 limit = forwarded / 2;
+        require(limit > 0, "limit must be positive");
+        stakingFactory.setEmissionsLimit(limit);
+
+        uint256 supplyBefore = IOLASForkL1(OLAS).totalSupply();
+        uint256 timelockBefore = IOLASForkL1(OLAS).balanceOf(TIMELOCK);
+
+        dispenser.claimStakingIncentives(1, CHAIN_ID, _targetBytes32(), "");
+
+        // Same amount minted, but split: cap staked, remainder refunded to the DAO Timelock
+        assertEq(IOLASForkL1(OLAS).totalSupply() - supplyBefore, forwarded, "totalSupply grew by the mint");
+        assertEq(stakingInstance.deposited(), limit, "only the emissions cap deposited into the target");
+        assertEq(IOLASForkL1(OLAS).balanceOf(TIMELOCK) - timelockBefore, forwarded - limit, "excess refunded to Timelock");
+        assertEq(IOLASForkL1(OLAS).balanceOf(address(processor)), 0, "processor holds no residual OLAS");
+    }
+}

--- a/test/StakingL2MigrateForkOP.t.sol
+++ b/test/StakingL2MigrateForkOP.t.sol
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Test} from "forge-std/Test.sol";
+import {OptimismTargetDispenserL2} from "../contracts/staking/OptimismTargetDispenserL2.sol";
+
+/// @dev Optimism-mainnet fork test of the migration's L2 leg (runbook §6 Phase 3): the per-chain
+///      pause -> migrate -> updateWithheldAmountMaintenance cutover of an L2 target dispenser onto its
+///      new instance, driven against the REAL Optimism OLAS token and the real OP-stack bridge addresses
+///      (baked as the dispensers' immutables).
+///
+///      What this uniquely exercises vs the mock-bridge unit tests in StakingBridging.js:
+///        - `DefaultTargetDispenserL2.l1DepositProcessor` is `immutable`, so a new L1 processor forces a new
+///          L2 dispenser — both are deployed fresh here and the OLAS balance is migrated between them on the
+///          live token;
+///        - `migrate()` transfers the full real-OLAS balance to the new dispenser, zeroes the old owner and
+///          locks the old contract permanently (one-way brick) — verified against live OLAS, not a mock ERC20;
+///        - the `Migrated` event surfaces `withheldAmount` (the value the DAO must restore), and
+///          `updateWithheldAmountMaintenance` re-establishes it on the new dispenser, which deploys at 0.
+///
+///      The contract name avoids the "Dispenser"/"Treasury"/"Depository" substrings so CI's fork-less
+///      `forge test --mc Dispenser|Treasury|Depository` allowlist does not pick it up and run it without a fork.
+///
+///      Run: forge test -f $FORK_OPTIMISM_NODE_URL --mc StakingL2MigrateForkOP -vvv
+
+interface IOLASForkL2 {
+    function balanceOf(address account) external view returns (uint256);
+}
+
+contract StakingL2MigrateForkOP is Test {
+    // Optimism mainnet addresses
+    address internal constant OLAS = 0xFC2E6e6BCbd49ccf3A5f029c79984372DcBFE527;
+    address internal constant STAKING_FACTORY = 0xa45E64d13A30a51b91ae0eb182e88a40e9b18eD8;
+    address internal constant L2_MESSENGER = 0x4200000000000000000000000000000000000007;
+    // A distinct new L1 deposit processor forces a new L2 target dispenser (immutable coupling)
+    address internal constant OLD_L1_PROCESSOR = 0x990aBa4b05adc3761EfAf38FB871b93C7b162D03;
+    address internal constant NEW_L1_PROCESSOR = 0x00000000000000000000000000000000DeaDBeef;
+    uint256 internal constant L1_SOURCE_CHAIN_ID = 1;
+
+    // OLAS carried on the L2 dispenser (withheld inflation) to be migrated
+    uint256 internal constant CARRIED = 12_345 ether;
+
+    // Mirror of DefaultTargetDispenserL2.Migrated for expectEmit
+    event Migrated(address indexed sender, address indexed newL2TargetDispenser, uint256 amount,
+        uint256 withheldAmount);
+
+    OptimismTargetDispenserL2 internal oldDispenser;
+    OptimismTargetDispenserL2 internal newDispenser;
+
+    function setUp() public {
+        // The new L1 processor forces a new L2 dispenser; deploy both (old bound to the old processor)
+        oldDispenser = new OptimismTargetDispenserL2(OLAS, STAKING_FACTORY, L2_MESSENGER, OLD_L1_PROCESSOR,
+            L1_SOURCE_CHAIN_ID);
+        newDispenser = new OptimismTargetDispenserL2(OLAS, STAKING_FACTORY, L2_MESSENGER, NEW_L1_PROCESSOR,
+            L1_SOURCE_CHAIN_ID);
+
+        // Seed the OLD dispenser with real OLAS (as undelivered/withheld inflation would sit on L2) and set its
+        // accounting withheldAmount to match (Phase 0 records this; it must be restored on the new contract)
+        deal(OLAS, address(oldDispenser), CARRIED);
+        oldDispenser.updateWithheldAmountMaintenance(CARRIED);
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 3 happy path: pause -> migrate -> restore withheld on the new dispenser
+    // -----------------------------------------------------------------------
+
+    function test_migrateCarriesRealOlasAndBricksOld() public {
+        assertEq(IOLASForkL2(OLAS).balanceOf(address(oldDispenser)), CARRIED, "old seeded with real OLAS");
+        assertEq(newDispenser.withheldAmount(), 0, "new dispenser deploys with withheldAmount == 0");
+        assertEq(newDispenser.l1DepositProcessor(), NEW_L1_PROCESSOR, "new dispenser bound to the new L1 processor");
+
+        // migrate requires paused
+        oldDispenser.pause();
+
+        // The Migrated event carries the exact amount + withheldAmount the DAO must restore
+        vm.expectEmit(true, true, false, true, address(oldDispenser));
+        emit Migrated(address(this), address(newDispenser), CARRIED, CARRIED);
+        oldDispenser.migrate(address(newDispenser));
+
+        // Real OLAS moved old -> new, in full
+        assertEq(IOLASForkL2(OLAS).balanceOf(address(oldDispenser)), 0, "old drained");
+        assertEq(IOLASForkL2(OLAS).balanceOf(address(newDispenser)), CARRIED, "new holds the migrated OLAS");
+
+        // Old contract is permanently bricked: owner zeroed, no further owner-gated interaction possible
+        assertEq(oldDispenser.owner(), address(0), "old owner zeroed");
+        vm.expectRevert();
+        oldDispenser.pause();
+        vm.expectRevert();
+        oldDispenser.migrate(address(newDispenser));
+
+        // Restore the withheld accounting on the new dispenser (Phase 3 step 12)
+        newDispenser.updateWithheldAmountMaintenance(CARRIED);
+        assertEq(newDispenser.withheldAmount(), CARRIED, "withheld restored on the new dispenser");
+    }
+
+    // -----------------------------------------------------------------------
+    // Guards on the live fork (belt-and-braces over the mock-bridge unit tests)
+    // -----------------------------------------------------------------------
+
+    function test_migrateGuards() public {
+        // Cannot migrate while unpaused
+        vm.expectRevert();
+        oldDispenser.migrate(address(newDispenser));
+
+        oldDispenser.pause();
+
+        // Cannot migrate to an EOA (must be a contract)
+        vm.expectRevert();
+        oldDispenser.migrate(address(0xBEEF));
+
+        // Cannot migrate to self
+        vm.expectRevert();
+        oldDispenser.migrate(address(oldDispenser));
+
+        // Not-owner cannot migrate
+        vm.prank(address(0xBAD));
+        vm.expectRevert();
+        oldDispenser.migrate(address(newDispenser));
+    }
+}

--- a/test/StakingL2MigrateForkOP.t.sol
+++ b/test/StakingL2MigrateForkOP.t.sol
@@ -37,8 +37,11 @@ contract StakingL2MigrateForkOP is Test {
     address internal constant NEW_L1_PROCESSOR = 0x00000000000000000000000000000000DeaDBeef;
     uint256 internal constant L1_SOURCE_CHAIN_ID = 1;
 
-    // OLAS carried on the L2 dispenser (withheld inflation) to be migrated
+    // Physical OLAS balance on the L2 dispenser, transferred in full by migrate()
     uint256 internal constant CARRIED = 12_345 ether;
+    // Accounting withheldAmount to restore on the new dispenser — deliberately BELOW the physical balance (as
+    // a residual would leave it), so the test proves the restore uses the emitted value, not the migrated balance
+    uint256 internal constant WITHHELD = 10_000 ether;
 
     // Mirror of DefaultTargetDispenserL2.Migrated for expectEmit
     event Migrated(address indexed sender, address indexed newL2TargetDispenser, uint256 amount,
@@ -55,9 +58,9 @@ contract StakingL2MigrateForkOP is Test {
             L1_SOURCE_CHAIN_ID);
 
         // Seed the OLD dispenser with real OLAS (as undelivered/withheld inflation would sit on L2) and set its
-        // accounting withheldAmount to match (Phase 0 records this; it must be restored on the new contract)
+        // accounting withheldAmount BELOW the balance (Phase 0 records this; it must be restored on the new one)
         deal(OLAS, address(oldDispenser), CARRIED);
-        oldDispenser.updateWithheldAmountMaintenance(CARRIED);
+        oldDispenser.updateWithheldAmountMaintenance(WITHHELD);
     }
 
     // -----------------------------------------------------------------------
@@ -72,9 +75,9 @@ contract StakingL2MigrateForkOP is Test {
         // migrate requires paused
         oldDispenser.pause();
 
-        // The Migrated event carries the exact amount + withheldAmount the DAO must restore
+        // The Migrated event carries the full migrated balance AND the (smaller) withheldAmount to restore
         vm.expectEmit(true, true, false, true, address(oldDispenser));
-        emit Migrated(address(this), address(newDispenser), CARRIED, CARRIED);
+        emit Migrated(address(this), address(newDispenser), CARRIED, WITHHELD);
         oldDispenser.migrate(address(newDispenser));
 
         // Real OLAS moved old -> new, in full
@@ -88,9 +91,10 @@ contract StakingL2MigrateForkOP is Test {
         vm.expectRevert();
         oldDispenser.migrate(address(newDispenser));
 
-        // Restore the withheld accounting on the new dispenser (Phase 3 step 12)
-        newDispenser.updateWithheldAmountMaintenance(CARRIED);
-        assertEq(newDispenser.withheldAmount(), CARRIED, "withheld restored on the new dispenser");
+        // Restore the withheld accounting from the EMITTED value (not the migrated balance) — Phase 3 step 12
+        newDispenser.updateWithheldAmountMaintenance(WITHHELD);
+        assertEq(newDispenser.withheldAmount(), WITHHELD, "withheld restored to the emitted value");
+        assertTrue(newDispenser.withheldAmount() != CARRIED, "restored withheld is not the migrated balance");
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
Stacked on #314. Makes `calculateStakingIncentives` a `view` function and moves all state effects up into the claim paths — the cleaner form of the item-12 fix discussed on #310/#315.

## What changed

**`calculateStakingIncentives` is now `view`.** It no longer checkpoints the nominee, sets `mapZeroWeightEpochRefunded`, or refunds. It returns a new sparse `zeroWeightEpochs[]` (indexed by `j - firstClaimedEpoch`; a non-zero slot is a zero-total-weight epoch — epoch numbers are never zero, so a zero slot means "not zero-weight") and folds each zero-weight epoch's incentive into `totalReturnAmount`. Consequences:
- A standalone call mutates nothing, so it can never strand a zero-weight epoch's inflation — the item-12 hazard is gone *by construction* (no gating/`eth_call`-from trick needed).
- It is directly `staticcall`-able for off-chain estimation.

**The claim paths own the effects.** `claimStakingIncentives` / `_calculateStakingIncentivesBatch` now checkpoint the nominee in Vote Weighting *before* the calculation and set `mapZeroWeightEpochRefunded` for the returned zero-weight epochs. In the batch orchestrator the flag is set **before the next target's call**, so the in-loop `mapZeroWeightEpochRefunded` skip dedupes zero-weight epochs shared across targets — each is refunded exactly once for the whole batch. The zero-weight amount rides the single aggregated `refundFromStaking` (no per-epoch refund calls).

**Rename** `_checkpointNomineeAndGetClaimedEpochCounters` → `_getClaimedEpochCounters`. It never checkpointed anything — `checkpointNominee` was always a separate call after it; "counters" are the claim cursors. NatSpec corrected.

**`checkpointNominee` ordering (corrected after review).** The real `VoteWeighting.checkpointNominee` **does** revert `NomineeDoesNotExist` for a never-added nominee (via `_getWeight`) — it is *not* a Curve-style no-op. So `checkpointNominee` is now guarded by `_requireClaimableNominee(stakingTarget, chainId)`, called **before** the checkpoint in both claim paths: it reverts `ZeroValue` when the Dispenser has no claim cursor, mirroring the first check of `_getClaimedEpochCounters`. This keeps `ZeroValue` the authoritative not-claimable error and ensures `checkpointNominee` is only ever reached for a live nominee — matching `retain()`, which already checks the cursor before checkpointing. `MockVoteWeighting.checkpointNominee` is restored to faithfully revert `NomineeDoesNotExist`; the guard means it is only reachable if the Dispenser and Vote Weighting ever disagree. (This replaces the earlier no-op-mock approach, which rested on the incorrect "real VW no-ops" premise flagged in review.)

## Tests
- Reworked the item-12 test: asserts the view call mutates nothing (flag unset, pot unchanged) and the claim refunds exactly once.
- Added `test_fix12_batchZeroWeight_dedupRefundsOnce` (two targets sharing a zero-weight epoch in one batch → refunded once) and `test_fix12_separateClaims_zeroWeight_noDoubleRefund` (cross-tx flag persistence).
- Added `test_claim_neverAddedNominee_revertsZeroValueBeforeCheckpoint` locking the guard ordering (claim reverts `ZeroValue`, not `NomineeDoesNotExist`); the existing reverse-order batch `ZeroValue` test now also catches a reorder regression.
- **Fork tests (this PR also adds the two migration-leg suites):** `test/StakingL1ProcessorForkETH.t.sol` (new Dispenser proxy vs a real `EthereumDepositProcessor`, ETH fork) and `test/StakingL2MigrateForkOP.t.sol` (L2 `pause → migrate → updateWithheldAmountMaintenance` on an Optimism fork; now uses `balance != withheld` so the restore assertion proves the emitted value is used). Both dodge the CI `--mc` allowlist by name, so they are manual-only.
- Added `test_setPauseState_requiresVoteWeighting_beforeGoLive` after rebasing onto #314 — exercises the merged-state interaction of zero-VW `initialize` + the go-live guard + `_requireClaimableNominee`.
- forge Dispenser 22/22, fork `StakingClaimForkETH` + `StakingL1ProcessorForkETH` 6/6, `StakingL2MigrateForkOP` 2/2, full `yarn test` 192 passing, solhint clean.

## ABI changes (for the redeploy regen list)

This PR changes the `calculateStakingIncentives` return tuple — it now returns a fifth value, the sparse `zeroWeightEpochs[]`. It is a `public` function used for off-chain estimation, so `abis/*/Dispenser.json` must be regenerated at redeploy, alongside the #314 constructor change and the #311 4-arg `Migrated` signature.

## Note

This branch was rebased onto the updated #314 (`cfceafb`) so the shipping combination — zero-VW `initialize` + `_requireClaimableNominee` + the go-live guard — is under test on one branch (commit hashes shifted accordingly).

