### PR TITLE
audit(internal19): Dispenser default-staking-param cleanup (PR #314) — GREEN-LIGHT

### DIFF
--- a/audits/internal19/README.md
+++ b/audits/internal19/README.md
@@ -6,10 +6,30 @@ head `refactor/dispenser-drop-default-staking-params` @ `86b35bf`, base
 `test/dispenser-deploy-forktest` @ `4fb597b`. Follow-up cleanup to the Dispenser-proxy rework
 (internal18) addressing the #309 review comments. Reviewed by hand + grounded on live mainnet.
 
+> **Amended 2026-08-13 by D. Minarsch** (original auditor no longer at the company). Two changes:
+> **§B.3 was factually wrong and is corrected in place** (see the correction block there), and the
+> coverage boundary below is now stated explicitly. Parts A and B are otherwise as originally written.
+>
+> **Coverage boundary.** Part A is pinned to `86b35bf` and Part B to `5a01465`. Both predate the
+> review-response commits that actually shipped, so the following are **covered by no audit**:
+>
+> | Commit | Change | Why it matters |
+> |---|---|---|
+> | `cf881af` | `initialize` accepts a zero `voteWeighting` | breaks the Dispenser ↔ VoteWeighting circular deploy; creates a live window where `voteWeighting == address(0)` |
+> | `cfceafb` | `setPauseState` rejects go-live while `voteWeighting == address(0)` | the guard that makes that window safe by construction rather than emergently |
+> | `7935707` | `_requireClaimableNominee` + `MockVoteWeighting` revert restored | the §B.3 correction |
+> | `0396533` | claim-loop invariant comments | closes OBS-1 |
+>
+> `cf881af` and `cfceafb` change contract behaviour and are material to deploy safety. They should be
+> picked up by the next audit round rather than assumed covered by this one.
+
 **Verdict: GREEN-LIGHT — no blocking finding.** The removals are safe cleanup: the deleted
 fallback is provably dead code on the live system, and no storage slot, live caller, or
 custody path is affected. One Informational observation (make the now-implicit cross-contract
-invariant explicit).
+invariant explicit) — **OBS-1, closed 2026-08-13 by `0396533`**.
+
+*Amendment note: the §B.3 conclusion below stands only as corrected in place; the reasoning
+originally given for it was wrong. See the correction block in §B.3.*
 
 ## Scope
 
@@ -54,6 +74,20 @@ not a divisor, and `maxStakingIncentive` is a *cap* (`:1028`). So a hypothetical
 `availableStakingAmount` at 0 → **zero incentives distributed** — no division-by-zero, no DoS, no
 over-payment. The removed net therefore only ever guarded a *benign* degradation, so removing it
 carries negligible risk even under invariant violation.
+
+> **Amended 2026-08-13 — a fourth, stronger reason the removal is safe.** The three checks above
+> establish the invariant *going forward*, and the on-chain reads cover epochs 44/45/46; epochs 1–43
+> are not inspected. That gap does not matter, because of a property not stated in the original
+> review: **a fresh Dispenser's claim cursors all start at the current epoch.** `_addNominee` sets
+> `mapLastClaimedStakingEpochs[nomineeHash] = ITokenomics(tokenomics).epochCounter()`, and
+> `_getClaimedEpochCounters` reverts `ZeroValue` on a zero cursor — so on this deployment no claim
+> path can ever traverse a pre-deployment epoch, whatever its staking point contains. The same holds
+> for the retainer, which is added through the identical path. `retain()` is unaffected either way,
+> as it reads neither `minStakingWeight` nor `maxStakingIncentive`.
+>
+> This is what makes the argument *complete* rather than merely well-evidenced: the fallback was not
+> unreachable code, it was reachable code made unreachable by a deployment property. Worth keeping in
+> mind if a future implementation ever seeds cursors from an earlier epoch.
 
 ## 2. Remove `Dispenser.changeStakingParams` + `StakingParamsUpdated` — SAFE
 
@@ -167,17 +201,57 @@ it is a net security improvement.**
   in-contract claim paths, both of which set-the-flag-and-refund together (verified above). This is
   strictly safer than the previous atomic-flag-and-refund form.
 
-## B.3 `checkpointNominee` hoisting + mock fidelity — no production behavior change
+## B.3 `checkpointNominee` hoisting + mock fidelity — CORRECTED
 
-Hoisting `checkpointNominee` ahead of the calc runs it before the Dispenser's own existence gate. On
-a non-existent nominee the real Vote Weighting `checkpointNominee` **no-ops** (Curve-style
-zero-initialized weight points — it does not revert), so the authoritative "exists for claiming"
-revert stays the Dispenser's `mapLastClaimedStakingEpochs` / `ZeroValue` check — a non-existent-nominee
-claim still reverts. The `MockVoteWeighting` revert that was removed was unfaithful to the real
-contract (and was previously unreachable via the Dispenser); the change only makes the test mock
-match production. No production path is weakened.
+> **Correction 2026-08-13 (amended by D. Minarsch; original auditor no longer at the company).**
+> This section as originally written was **factually wrong**, and it green-lit a change that was
+> subsequently reverted for exactly that reason. It read:
+>
+> > On a non-existent nominee the real Vote Weighting `checkpointNominee` **no-ops** (Curve-style
+> > zero-initialized weight points — it does not revert) … The `MockVoteWeighting` revert that was
+> > removed was unfaithful to the real contract … No production path is weakened.
+>
+> The real contract **does** revert. `VoteWeighting.checkpointNominee`
+> (`autonolas-governance/contracts/VoteWeighting.sol:403`) calls `_getWeight`, which opens with:
+>
+> ```solidity
+> if (mapRemovedNominees[nomineeHash] == 0 && mapNomineeIds[nomineeHash] == 0) {
+>     revert NomineeDoesNotExist(account, chainId);
+> }
+> ```
+>
+> The claim was carried over from the PR description without being checked against the other
+> repository. It was raised in review on #315, the author agreed, and it was fixed in `7935707`
+> before merge. The corrected analysis of the **shipped** code follows.
 
-## B.4 Tests — 19/19 forge unit, re-run firsthand
+Hoisting `checkpointNominee` ahead of the calculation runs it before the Dispenser's own claim-cursor
+gate, so on the pre-`7935707` code a claim for a never-added nominee would have reverted
+`NomineeDoesNotExist` from Vote Weighting rather than `ZeroValue` from the Dispenser — a changed error
+surface on a public entry point, invisible to the suite because the mock had been altered to no-op.
+
+The shipped code closes this on both sides:
+
+- **`MockVoteWeighting.checkpointNominee` reverts again** (`contracts/test/MockVoteWeighting.sol:39-44`),
+  faithfully mirroring the real `_getWeight` guard, so the suite once more exercises the real error
+  surface.
+- **`_requireClaimableNominee(stakingTarget, chainId)`** was added and is called in both claim paths
+  *before* `checkpointNominee`. It mirrors the first check in `_getClaimedEpochCounters`
+  (`mapLastClaimedStakingEpochs[nomineeHash] == 0 → ZeroValue`), so `ZeroValue` is once again the
+  authoritative "not claimable" error and `checkpointNominee` is only ever reached for a live nominee.
+
+Two properties worth recording, both verified against the merged contract:
+
+- **Removed nominees still checkpoint.** `_requireClaimableNominee` passes for a removed nominee (its
+  cursor is non-zero), and the real `_getWeight` short-circuits on `mapRemovedNominees[hash] != 0`, so
+  it does not revert. Claiming residual pre-removal epochs continues to work.
+- **`retain()` needs no guard.** It already calls `_getClaimedEpochCounters` — carrying the same
+  `firstClaimedEpoch == 0` check — before `checkpointNominee`, so the ordering the new guard imposes
+  on the claim paths was already correct there.
+
+**Verdict for B.3: correct as shipped.** No production path is weakened, but that conclusion rests on
+`7935707`, not on the reasoning originally given here.
+
+## B.4 Tests — 19/19 forge unit at the pinned commit (22/22 on merged `main`)
 
 `forge test --mc Dispenser` (unit) → **19/19 PASS** re-run in this review, including the three
 item-12 tests that directly exercise the analysis above:
@@ -187,10 +261,20 @@ once), `test_fix12_separateClaims_zeroWeight_noDoubleRefund` (cross-tx flag pers
 `StakingClaimForkETH` fork test (author reports 3/3) was not re-run here (needs an archive mainnet
 RPC unavailable in-environment).
 
+> **Amended 2026-08-13.** The 19/19 figure is correct for the pinned commit `5a01465`. Merged `main`
+> carries **22/22** (Dispenser 3, DispenserProxy 11, DispenserFixes 8) — the additional tests are
+> `7935707`'s claimable-guard coverage and `98cfee5`'s `test_setPauseState_requiresVoteWeighting_beforeGoLive`,
+> which exercises the merged-state interaction of the zero-VW `initialize` and the go-live guard.
+
 ## B.5 Verdict
 
 **GREEN-LIGHT.** Making `calculateStakingIncentives` `view` and moving the effects into the claim
 paths is correct — exactly-once refund preserved (batch + cross-tx, tested), encoding collision-free,
 compiler-enforced view — and it eliminates the item-12 self-mutation hazard by construction, a net
-security improvement. No new finding; no OBS beyond OBS-1 above (still applies to the shared claim
-loop).
+security improvement. No new finding.
+
+> **Amended 2026-08-13 — OBS-1 is closed.** `0396533` (#315) added the cross-contract invariant at
+> the claim loop (`contracts/Dispenser.sol:1034-1038` on merged `main`). The wording names both
+> Tokenomics mechanisms that uphold it (`changeStakingParams` zero-reject and the epoch
+> carry-forward) and the benign failure mode if it were ever violated, which is what OBS-1 asked
+> for. No action outstanding.

--- a/audits/internal19/README.md
+++ b/audits/internal19/README.md
@@ -1,4 +1,4 @@
-# Autonolas Tokenomics — Internal Audit: Dispenser default-staking-param cleanup (internal19)
+# Autonolas Tokenomics — Internal Audit: Dispenser cleanup stack — PR #314 + #315 (internal19)
 
 Releasing-audit review of **PR #314**
 (`refactor(Dispenser): drop default staking-param fallback + obsolete changeStakingParams`),
@@ -119,3 +119,78 @@ behavior-neutral on the live system and benign even under invariant violation; `
 had no live caller and its bounds are set at `initialize()`; the immutable/constructor changes
 touch no proxy storage slot; 17/17 unit tests pass firsthand. Address **OBS-1** (document the
 cross-contract invariant) as hardening — not a blocker.
+
+
+---
+
+# PART B — PR #315: make `calculateStakingIncentives` view; move effects to the claim path
+
+Review of **PR #315** (`refactor(Dispenser): make calculateStakingIncentives view; move effects to
+the claim path`), head `refactor/dispenser-view-calculate-staking-incentives` @ `5a01465`, **stacked
+on #314**. +148/−46 across `Dispenser.sol`, `MockVoteWeighting.sol` (test), `DispenserFixes.t.sol`.
+The cleaner form of the item-12 (vuln-list #12) fix. **Verdict: GREEN-LIGHT — no blocking finding;
+it is a net security improvement.**
+
+## B.1 What changed
+
+- **`calculateStakingIncentives` is now `public view`.** It no longer checkpoints the nominee, no
+  longer writes `mapZeroWeightEpochRefunded`, and no longer calls `refundFromStaking`. It returns a
+  new sparse `uint256[] zeroWeightEpochs` (indexed by `j − firstClaimedEpoch`; a non-zero slot holds
+  the zero-total-weight epoch number) and folds each zero-weight epoch's incentive into
+  `totalReturnAmount`.
+- **The two claim paths own the effects** — `claimStakingIncentives` (single) and
+  `_calculateStakingIncentivesBatch` (batch): each now calls `checkpointNominee` **before** the view
+  calc, then sets `mapZeroWeightEpochRefunded` for every returned zero-weight epoch, and refunds via
+  the existing aggregated `refundFromStaking(returnAmount)` (single) / `totalAmounts[2]` (batch).
+- Rename `_checkpointNomineeAndGetClaimedEpochCounters` → `_getClaimedEpochCounters` (it never
+  checkpointed — NatSpec corrected). `MockVoteWeighting.checkpointNominee` no longer reverts on an
+  unregistered nominee (test-only fidelity fix, see B.3).
+
+## B.2 Correctness — verified firsthand
+
+- **Genuinely `view`, compiler-enforced.** `IVoteWeighting.nomineeRelativeWeight` is declared
+  `external view` (`Dispenser.sol:189`), so the loop's only external call reads state; the function
+  compiles as `public view` (i.e. no SSTORE and no state-mutating call remain — `forge build`
+  succeeds). The state-mutating `checkpointNominee` was hoisted out to the callers.
+- **Exactly-once refund — the dedup is intact.** The loop keeps its head guard
+  `if (mapZeroWeightEpochRefunded[j]) continue;`. Combined with the batch setting the flag **before
+  the next target's calc**, a zero-weight epoch shared across targets is folded into exactly one
+  target's `returnAmount` (later targets skip it), and a second claim tx re-traversing an
+  already-refunded epoch skips it too. The aggregated batch refund is `totalAmounts[2] += returnAmount`
+  → a single `refundFromStaking`; no per-epoch refund calls, no double refund, no stranded inflation.
+- **Encoding is sound.** `zeroWeightEpochs` is sized `lastClaimedEpoch − firstClaimedEpoch`; epoch
+  numbers are always ≥ 1 (epoch 0 is never claimable), so the `0 = not-a-zero-weight-epoch` sentinel
+  can never collide with a real epoch.
+- **Item-12 hazard gone by construction.** Because the function mutates nothing, a standalone
+  external call can neither mark an epoch refunded-without-refund nor strand inflation — and it is now
+  directly `staticcall`-able for off-chain estimation. Effect-correctness is confined to the two
+  in-contract claim paths, both of which set-the-flag-and-refund together (verified above). This is
+  strictly safer than the previous atomic-flag-and-refund form.
+
+## B.3 `checkpointNominee` hoisting + mock fidelity — no production behavior change
+
+Hoisting `checkpointNominee` ahead of the calc runs it before the Dispenser's own existence gate. On
+a non-existent nominee the real Vote Weighting `checkpointNominee` **no-ops** (Curve-style
+zero-initialized weight points — it does not revert), so the authoritative "exists for claiming"
+revert stays the Dispenser's `mapLastClaimedStakingEpochs` / `ZeroValue` check — a non-existent-nominee
+claim still reverts. The `MockVoteWeighting` revert that was removed was unfaithful to the real
+contract (and was previously unreachable via the Dispenser); the change only makes the test mock
+match production. No production path is weakened.
+
+## B.4 Tests — 19/19 forge unit, re-run firsthand
+
+`forge test --mc Dispenser` (unit) → **19/19 PASS** re-run in this review, including the three
+item-12 tests that directly exercise the analysis above:
+`test_fix12_viewCalculate_zeroWeight_refundsOnceViaClaim` (view mutates nothing; claim refunds once),
+`test_fix12_batchZeroWeight_dedupRefundsOnce` (two targets sharing a zero-weight epoch → refunded
+once), `test_fix12_separateClaims_zeroWeight_noDoubleRefund` (cross-tx flag persistence). The
+`StakingClaimForkETH` fork test (author reports 3/3) was not re-run here (needs an archive mainnet
+RPC unavailable in-environment).
+
+## B.5 Verdict
+
+**GREEN-LIGHT.** Making `calculateStakingIncentives` `view` and moving the effects into the claim
+paths is correct — exactly-once refund preserved (batch + cross-tx, tested), encoding collision-free,
+compiler-enforced view — and it eliminates the item-12 self-mutation hazard by construction, a net
+security improvement. No new finding; no OBS beyond OBS-1 above (still applies to the shared claim
+loop).

--- a/audits/internal19/README.md
+++ b/audits/internal19/README.md
@@ -1,0 +1,121 @@
+# Autonolas Tokenomics — Internal Audit: Dispenser default-staking-param cleanup (internal19)
+
+Releasing-audit review of **PR #314**
+(`refactor(Dispenser): drop default staking-param fallback + obsolete changeStakingParams`),
+head `refactor/dispenser-drop-default-staking-params` @ `86b35bf`, base
+`test/dispenser-deploy-forktest` @ `4fb597b`. Follow-up cleanup to the Dispenser-proxy rework
+(internal18) addressing the #309 review comments. Reviewed by hand + grounded on live mainnet.
+
+**Verdict: GREEN-LIGHT — no blocking finding.** The removals are safe cleanup: the deleted
+fallback is provably dead code on the live system, and no storage slot, live caller, or
+custody path is affected. One Informational observation (make the now-implicit cross-contract
+invariant explicit).
+
+## Scope
+
+| File | Change |
+|---|---|
+| `contracts/Dispenser.sol` | +5 / −57 — remove `defaultMin/MaxStaking*` immutables + claim-time fallback; remove `changeStakingParams` + event; constructor 5→3 args; pragma 0.8.30 |
+| `contracts/proxies/DispenserProxy.sol` | +2 / −1 — pragma 0.8.30 + co-author only |
+| `scripts/deployment/deploy_07a_dispenser.sh` | constructor args 5→3 |
+| `test/*` (6 files) | updated for the 3-arg constructor; dropped the removed-setter test; re-exercise `Overflow` via a `(1,1)` bounds instance |
+
+## 1. Remove `defaultMinStakingWeight` / `defaultMaxStakingIncentive` + claim-time fallback — SAFE
+
+The removed block, in the staking-incentive claim loop:
+```solidity
+if (stakingPoint.stakingFraction > 0) {
+    if (stakingPoint.minStakingWeight == 0 && stakingPoint.maxStakingIncentive == 0) {
+        stakingPoint.minStakingWeight  = uint16(defaultMinStakingWeight);
+        stakingPoint.maxStakingIncentive = uint96(defaultMaxStakingIncentive);
+    }
+} else { continue; }
+```
+collapses to `if (stakingPoint.stakingFraction == 0) continue;`. The fallback fires only in the
+state `stakingFraction > 0 && minStakingWeight == 0 && maxStakingIncentive == 0`. That state is
+**unreachable on the live Tokenomics** — verified three ways:
+
+- **`Tokenomics.changeStakingParams` rejects zero** for both params
+  (`Tokenomics.sol:767` — `if (_maxStakingIncentive == 0 || _minStakingWeight == 0) revert ZeroValue();`),
+  so neither can ever be *set* to zero while the staking system is active.
+- **Epoch settlement carries the values forward unconditionally.** At checkpoint, when staking
+  params were not re-requested, `mapEpochStakingPoints[eCounter+1].{max,min}` are copied straight
+  from `[eCounter]` (`Tokenomics.sol:1236–1237`, the `else` branch). So once non-zero, they stay
+  non-zero in every subsequent epoch.
+- **On-chain, live Tokenomics proxy `0xc096362fa6f4A4B1a9ea68b1043416f3381ce300`** (read 2026-08-04,
+  epochCounter = 46): epochs 44/45/46 each report `stakingFraction = 75`,
+  `maxStakingIncentive = 60000e18`, `minStakingWeight = 50` — all non-zero. The fallback trigger
+  is absent and, by the two invariants above, cannot arise going forward.
+
+**Blast radius if the invariant were ever broken (defense-in-depth check).** Downstream,
+`minStakingWeight` is a *threshold* (`Dispenser.sol:1018` — `if (stakingWeight < minStakingWeight * 1e14)`),
+not a divisor, and `maxStakingIncentive` is a *cap* (`:1028`). So a hypothetical
+`min == 0 && max == 0` state would make the min-weight gate permissive **but** cap
+`availableStakingAmount` at 0 → **zero incentives distributed** — no division-by-zero, no DoS, no
+over-payment. The removed net therefore only ever guarded a *benign* degradation, so removing it
+carries negligible risk even under invariant violation.
+
+## 2. Remove `Dispenser.changeStakingParams` + `StakingParamsUpdated` — SAFE
+
+- **No live caller.** No deployment or proposal script calls `Dispenser.changeStakingParams`
+  (the two `changeStakingParams` references in `scripts/proposals/*` target
+  **`Tokenomics.changeStakingParams`**, which is retained). Confirmed by grep across `scripts/`.
+- `maxNumClaimingEpochs` / `maxNumStakingTargets` are set (with a zero-check) in `initialize()`
+  (`Dispenser.sol:389–390`, in `initialize()`), so they are established at proxy init.
+- **Consequence — deliberate:** these two bounds become **set-once at `initialize()`** with no
+  runtime setter. This removes a governance tuning lever; it is recoverable because the Dispenser
+  is proxy-upgradeable (a future implementation can reintroduce a setter). Acceptable design
+  reduction, flagged by the author.
+
+## 3. Constructor 5→3 + immutable removal — storage-layout-safe (proxy)
+
+The removed `defaultMin/MaxStaking*` are **immutables** (implementation bytecode, not proxy
+storage), and only a function + an event were removed besides — **no storage variable was removed
+or reordered**, so the proxy storage layout is preserved and the upgrade is safe. The constructor
+now takes `(olas, tokenomics, retainer)`; `deploy_07a_dispenser.sh` was updated to the 3-arg
+`abi-encode("constructor(address,address,bytes32)")`. `DispenserProxy.sol` changes are pragma +
+co-author only — `PROXY_DISPENSER` slot (`keccak256("PROXY_DISPENSER")`) and the delegatecall path
+are untouched.
+
+## 4. Tests
+
+- **`forge test --mc Dispenser` (unit) — 17/17 PASS, re-run firsthand:** DispenserProxy 9 (incl.
+  `changeImplementation_swapsLogicAndPreservesState`, reinit guards), DispenserFixes 5 (the
+  vuln-list #8/#9/#12/#25 regressions), Dispenser 3 (the incentive-loop claim path that exercises
+  the now-fallback-free branch). `DispenserFixes` correctly sets the staking params explicitly and
+  the `(1,1)` bounds instance re-exercises the `Overflow` paths that the dropped DAO-setter test
+  used to cover.
+- **`StakingClaimForkETH` (mainnet-fork proxied claim path) — dev reports 3/3;** not re-run here
+  (the fork needs an archive mainnet RPC / alias not available in this environment). The specific
+  claim it validates — the live staking points carry non-zero `min`/`max` so the removed fallback
+  never fires — is instead grounded independently by the on-chain reads in §1.
+
+## 5. Out of scope (flagged by the author — acknowledged)
+
+- `abis/*/Dispenser.json` + `docs/configuration.json` still carry a stale Dispenser ABI (old 9-arg
+  constructor, already stale since the #309 proxy refactor). ABI regeneration is a release-artifact
+  step at redeploy — correct to defer.
+- `Vulnerabilities_list_tokenomics.md` unchanged — those entries clear only after the physical
+  redeploy + rewiring.
+
+## 6. Observation (Informational — non-blocking)
+
+**OBS-1 — the removed fallback made an implicit cross-contract invariant load-bearing.** After
+this change the Dispenser claim path relies on Tokenomics never emitting a `stakingFraction > 0`
+StakingPoint with `minStakingWeight == 0 && maxStakingIncentive == 0`. That holds today (§1), but
+it is now an *undocumented* dependency spanning two independently-upgradeable proxies. Recommend
+making it explicit — a one-line NatSpec at the claim site (e.g. "assumes Tokenomics guarantees
+non-zero min/max whenever stakingFraction > 0; enforced by changeStakingParams zero-reject +
+epoch carry-forward") and/or a note in `Vulnerabilities_list_tokenomics.md` — so a future
+Tokenomics change that could set `stakingFraction > 0` before the staking params (e.g. a fresh
+deployment ordering) surfaces the Dispenser dependency rather than silently distributing zero
+incentives. Cheap, and it removes the only non-obvious risk in this PR.
+
+## Verdict
+
+**GREEN-LIGHT.** The default-staking-param fallback is proven dead code on the live Tokenomics
+(zero-reject + unconditional epoch carry-forward, confirmed by on-chain reads), its removal is
+behavior-neutral on the live system and benign even under invariant violation; `changeStakingParams`
+had no live caller and its bounds are set at `initialize()`; the immutable/constructor changes
+touch no proxy storage slot; 17/17 unit tests pass firsthand. Address **OBS-1** (document the
+cross-contract invariant) as hardening — not a blocker.


### PR DESCRIPTION
Standalone internal-audit record for **#314** (`refactor(Dispenser): drop default staking-param fallback + obsolete changeStakingParams`). Follow-up cleanup to the Dispenser-proxy rework (internal18), addressing the #309 review comments. Adds `audits/internal19/README.md`.

**Verdict: GREEN-LIGHT — no blocking finding.** Reviewed by hand + grounded on live mainnet.

- **Removed fallback is provably dead code on the live Tokenomics** — verified 3 ways: `Tokenomics.changeStakingParams` zero-reject (`:767`) + unconditional epoch carry-forward of `min`/`max` (`:1236–1237`) + on-chain reads of the live proxy `0xc096362fa6f4A4B1a9ea68b1043416f3381ce300` (epochs 44–46: `stakingFraction=75`, `maxStakingIncentive=60000e18`, `minStakingWeight=50`, all non-zero). Even if the invariant broke, the blast radius is benign (`min` is a threshold not a divisor; `max=0` caps incentives at 0) — no div-by-zero, DoS, or over-payment.
- **`Dispenser.changeStakingParams` has no live caller** (the two proposal references target the retained `Tokenomics.changeStakingParams`); `maxNumClaimingEpochs`/`maxNumStakingTargets` are set at `initialize()` (`:389–390`), set-once, recoverable via the proxy upgrade path.
- **Storage-layout safe:** only immutables + a function + an event were removed — no storage slot changed; `DispenserProxy` is pragma + co-author only (`PROXY_DISPENSER` slot + delegatecall untouched); `deploy_07a` updated to the 3-arg `abi-encode`.
- **`forge test --mc Dispenser` → 17/17 re-run firsthand.** The `StakingClaimForkETH` mainnet-fork test is the author's evidence; not re-run here (needs an archive mainnet RPC unavailable in-environment) — the live-state claim it checks is instead grounded by the on-chain reads above.

One Informational observation (**OBS-1**): the removal makes an implicit cross-contract invariant load-bearing — recommend documenting it at the claim site / in `Vulnerabilities_list_tokenomics.md`. Full detail in `audits/internal19/README.md`.