### PR TITLE
fix(config): point configuration.json at the renamed LiquidityManager artifacts

### DIFF
--- a/docs/configuration.json
+++ b/docs/configuration.json
@@ -103,8 +103,8 @@
         "address": "0x8C31cd6d5d90BB536e045A59C71b85154De1C190"
       },
       {
-        "name": "LiquidityManagerETH",
-        "artifact": "abis/0.8.30/LiquidityManagerETH.json",
+        "name": "LiquidityManagerUniV2UniV3",
+        "artifact": "abis/0.8.30/LiquidityManagerUniV2UniV3.json",
         "address": "0x0171D7178fbf3B48E75675DEE2EA3EfecEf775C1"
       },
       {
@@ -242,8 +242,8 @@
         "address": "0xDC175E77d11246c79B23D7088750eb59160DD6b7"
       },
       {
-        "name": "LiquidityManagerOptimism",
-        "artifact": "abis/0.8.30/LiquidityManagerOptimism.json",
+        "name": "LiquidityManagerBalancerSlipstream",
+        "artifact": "abis/0.8.30/LiquidityManagerBalancerSlipstream.json",
         "address": "0xCf9B4710fe450Dca52374f28e4917FDCd44F9487"
       },
       {
@@ -288,8 +288,8 @@
         "address": "0x96a475Cf364999dE5317d13f66E8e3c072bA1c0a"
       },
       {
-        "name": "LiquidityManagerOptimism",
-        "artifact": "abis/0.8.30/LiquidityManagerOptimism.json",
+        "name": "LiquidityManagerBalancerSlipstream",
+        "artifact": "abis/0.8.30/LiquidityManagerBalancerSlipstream.json",
         "address": "0x1D64516E7654F23dB7cE2ddaD00FFb3E765cf5ce"
       },
       {


### PR DESCRIPTION
Follow-up to #319, which renamed the LiquidityManager leaves by capability and deleted the old chain-named ABI artifacts. `docs/configuration.json` was the one consumer the rename did not reach.

## Two live breakages on `main`

**1. Dangling artifact paths.** All three entries point at files #319 deleted:

```
abis/0.8.30/LiquidityManagerETH.json         MISSING
abis/0.8.30/LiquidityManagerOptimism.json    MISSING
```

**2. The on-chain audit script is broken — this is the one that matters.** #319 also updated `scripts/audit_chains/audit_contracts_setup.js` to look these contracts up by their **new** names:

```js
await checkLiquidityManagerImpl(providers[0], mDg.pol, configs[0]["contracts"], "LiquidityManagerUniV2UniV3", log);
await checkLiquidityManagerImpl(providers[chainNumber], dg.pol, configs[chainNumber]["contracts"], "LiquidityManagerBalancerSlipstream", log);
```

…while `configuration.json` still supplied `LiquidityManagerETH` / `LiquidityManagerOptimism`. `findContractInstance` returns `undefined` on a name miss, so `impl.address` throws — the audit crashes at its first LiquidityManager check, on every configured chain. It fails loudly rather than passing vacuously, which is the better failure mode, but it means the chain-audit is currently unusable.

## The change

Names and artifact paths only, following #319's own capability table:

| chain | was | now |
|---|---|---|
| mainnet | `LiquidityManagerETH` | `LiquidityManagerUniV2UniV3` |
| optimism | `LiquidityManagerOptimism` | `LiquidityManagerBalancerSlipstream` |
| base | `LiquidityManagerOptimism` | `LiquidityManagerBalancerSlipstream` |

**Addresses are untouched.** The implementations deployed behind those proxies are unchanged and still predate the POL redeploy — this corrects how the config *names* them, not what it points at on-chain.

## Verification

- `configuration.json` parses.
- It references **zero** missing artifacts (was 3).
- Every `LiquidityManager*` name it declares is one `audit_contracts_setup.js` actually looks up — checked both directions.

## Note

This is the third instance this cycle of a rename reaching the contracts, scripts and ABIs but not a consumer that keys off names: the `dispenserAddress` → `dispenserProxyAddress` split (caught in review on #309, swept in #314), the `internal18` audit-number collision (#306), and now this. Worth a grep for the old identifier across `docs/`, `scripts/` and `abis/` as a standing step whenever a contract is renamed — all three were mechanical to find once someone looked.
