### PR TITLE
Prototype: V2-removed-ratio vs V3-slot0 manipulation cross-check (oracle-drop analysis, #324)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ forge test --mc LPSwapCeloSlippageTest -vvv
 ```bash
 forge test -f $FORK_ETH_NODE_URL --mc LiquidityManagerUniV2UniV3 -vvv  # ETH mainnet (UniV2 -> UniV3)
 forge test -f $FORK_ETH_NODE_URL --mc LiquidityManagerUniV2UniV3BridgeForkETH -vvv  # ETH fork of the UniV2 -> UniV3 L2-burn manager (Celo)
+forge test -f $FORK_ETH_NODE_URL --mc LiquidityManagerV2V3CrossCheckForkETH -vvv  # #324 prototype: V2-removed ratio vs V3-slot0 manipulation cross-check (oracle-drop analysis)
 forge test -f $FORK_ETH_NODE_URL --mc LiquidityManagerObservationCardinalityGasETH -vvv
 forge test -f $FORK_ETH_NODE_URL --mc UniswapPriceOracleETH -vvv
 forge test -f $FORK_ETH_NODE_URL --mc BuyBackBurnerUniswapETH -vvv

--- a/contracts/pol/LiquidityManagerBalancerUniV3.sol
+++ b/contracts/pol/LiquidityManagerBalancerUniV3.sol
@@ -11,7 +11,7 @@ import {LiquidityManagerBurnViaBridge} from "./LiquidityManagerBurnViaBridge.sol
 /// @author Andrey Lebedev - <andrey.lebedev@valory.xyz>
 /// @author Mariapia Moscatiello - <mariapia.moscatiello@valory.xyz>
 /// @dev Converts protocol-owned Balancer V2 liquidity into a canonical Uniswap V3 concentrated position, for L2s
-///      that run Balancer as the source DEX and Uniswap V3 as the target. Pure composition of the audited
+///      that run Balancer as the source DEX and Uniswap V3 as the target. Pure composition of the existing
 ///      Balancer-source, UniV3-target and L2-burn mixins — it declares no logic of its own.
 contract LiquidityManagerBalancerUniV3 is
     LiquidityManagerSourceBalancer,

--- a/contracts/pol/LiquidityManagerCore.sol
+++ b/contracts/pol/LiquidityManagerCore.sol
@@ -121,10 +121,10 @@ abstract contract LiquidityManagerCore is ERC721TokenReceiver {
         0xf7d1f641b01c7d29322d281367bfc337651cbfb5a9b1c387d2132d8792d212cd;
     // Max allowed slot0-vs-TWAP price deviation (2%) in 1e18 format. Pre-flight anti-manipulation gate on
     // entries/trades: rejects an operation when slot0 has been pushed more than this far from the TWAP.
-    // Post-#306.1 the entry `amount{0,1}Min` is anchored to slot0 (vacuous by construction), so this gate is
-    // the SOLE entry manipulation defence — tightened from 10% to 2% per internal20 R6 (on a shallow,
-    // ~fully-POL pool a 10% push is buyable for ~0.1% of the position). Treat any change as a security
-    // change, not a tuning knob.
+    // The entry `amount{0,1}Min` is anchored to slot0 (vacuous by construction), so this gate is the SOLE
+    // entry manipulation defence — set to 2% because on a shallow, ~fully-POL pool a wider (e.g. 10%) push is
+    // buyable for a tiny fraction (~0.1%) of the position. Treat any change as a security change, not a
+    // tuning knob.
     uint256 public constant MAX_ALLOWED_DEVIATION = 2e16;
     // Seconds ago to look back for TWAP pool values
     uint32 public constant SECONDS_AGO = 1800;
@@ -147,12 +147,11 @@ abstract contract LiquidityManagerCore is ERC721TokenReceiver {
     // Owner address
     address public owner;
 
-    // Max slippage for pool operations (in BPS, bound by 10_000). Post-#306.1 it no longer backstops V3
-    // mints (the entry `amount{0,1}Min` is slot0-anchored, so that amount-space check is vacuous); its live
-    // role is the source-side floor on the V2/Balancer `removeLiquidity`/`exitPool` (the fair-reserve
-    // discount in the source mixin). It is therefore DECOUPLED from `MAX_ALLOWED_DEVIATION` — set it from the
-    // source pool's expected spot-vs-TWAP drift, not the gate. Seeded at `initialize`, tunable via
-    // `changeMaxSlippage`.
+    // Max slippage for pool operations (in BPS, bound by 10_000). It does not backstop V3 mints (the entry
+    // `amount{0,1}Min` is slot0-anchored, so that amount-space check is vacuous); its live role is the
+    // source-side floor on the V2/Balancer `removeLiquidity`/`exitPool` (the fair-reserve discount in the
+    // source mixin). It is therefore DECOUPLED from `MAX_ALLOWED_DEVIATION` — set it from the source pool's
+    // expected spot-vs-TWAP drift, not the gate. Seeded at `initialize`, tunable via `changeMaxSlippage`.
     uint16 public maxSlippage;
 
     // Reentrancy lock
@@ -396,9 +395,9 @@ abstract contract LiquidityManagerCore is ERC721TokenReceiver {
     /// @dev slot0-anchored min amounts for an entry into [tickLower, tickUpper] with the given desired amounts.
     /// @notice Mirrors what the position manager does at execution (getLiquidityForAmounts then
     ///         getAmountsForLiquidity at slot0), so amountMin is always satisfiable at the price the mint /
-    ///         increase executes at — the fix for the TWAP-vs-slot0 dead band (finding #306.1). The range stays
-    ///         placed around the TWAP center; only the floor moves to slot0, exactly as _decreaseLiquidity does
-    ///         on the exit. Manipulation resistance stays in the pre-flight checkPoolAndGetCenterPrice gate.
+    ///         increase executes at — avoiding the TWAP-vs-slot0 dead band. The range stays placed around the
+    ///         TWAP center; only the floor moves to slot0, exactly as _decreaseLiquidity does on the exit.
+    ///         Manipulation resistance stays in the pre-flight checkPoolAndGetCenterPrice gate.
     /// @param slot0SqrtPriceX96 slot0 (execution) sqrt price.
     /// @param tickLower Lower tick of the position range.
     /// @param tickUpper Upper tick of the position range.
@@ -485,7 +484,7 @@ abstract contract LiquidityManagerCore is ERC721TokenReceiver {
     ///         This operates on `balanceOf(this)` and is used only by the owner-only entry/exit paths
     ///         (convertToV3 / increaseLiquidity / decreaseLiquidity / changeRanges), where sweeping the whole
     ///         balance is intended. The permissionless collectFees instead passes just the collected fees to
-    ///         the shared _manageAmounts primitive, so it cannot burn separately-staged OLAS (VL#15).
+    ///         the shared _manageAmounts primitive, so it cannot burn separately-staged OLAS.
     /// @param tokens Token addresses.
     /// @param utilizationRate Token utilization rate, in BPS.
     /// @param olasBurnOrTransfer True if OLAS is burnt, false if transferred to treasury.
@@ -522,7 +521,7 @@ abstract contract LiquidityManagerCore is ERC721TokenReceiver {
     ///         collectFees path funnel through here, so the OLAS-ordering / burn-vs-transfer / event logic
     ///         lives in exactly one place. Passing explicit amounts (rather than reading balanceOf) is what
     ///         lets collectFees handle only the just-collected fees and leave separately-staged OLAS
-    ///         untouched (VL#15).
+    ///         untouched.
     /// @param tokens Token addresses.
     /// @param amounts Amounts to manage, parallel to tokens.
     /// @param olasBurnOrTransfer True if OLAS is burnt, false if transferred to treasury.
@@ -599,8 +598,8 @@ abstract contract LiquidityManagerCore is ERC721TokenReceiver {
         }
 
         // Range placement stays anchored to the TWAP center (sqrtP, manipulation-resistant), but amountMin is
-        // anchored to slot0 — the exact price NPM.mint() executes at. Otherwise a slot0 != TWAP within the 10%
-        // gate creates a dead band where the pre-flight guard accepts but the mint reverts (finding #306.1).
+        // anchored to slot0 — the exact price NPM.mint() executes at. Otherwise a slot0 != TWAP within the
+        // deviation gate creates a dead band where the pre-flight guard accepts but the mint reverts.
         // Mirrors _decreaseLiquidity; manipulation resistance stays in the caller's checkPoolAndGetCenterPrice.
         (uint160 slot0Sqrt,) = _getPriceAndObservationIndexFromSlot0(_getV3Pool(tokens, feeTierOrTickSpacing));
         uint256[] memory aMin = _slot0MinAmounts(slot0Sqrt, optimizedTicks[0], optimizedTicks[1], amountsIn);
@@ -764,10 +763,7 @@ abstract contract LiquidityManagerCore is ERC721TokenReceiver {
             amounts = _manageUtilityAmounts(tokens, olasBurnRate, true);
         }
 
-        // Check current pool prices. NOTE (#324): this gate-verified sqrtP (within 2% of the V3 TWAP) is also the
-        // trusted reference the proposed source-side cross-check would reuse — asserting the V2-removed A:B ratio in
-        // `amounts` matches it — to drop `oracleV2`/`_fairMinAmountsOut` without losing a manipulation gate. The gate
-        // here also guarantees that reference is only trusted on a warmed pool (an unseeded pool's slot0 is stale).
+        // Check current pool prices
         uint160 sqrtP = checkPoolAndGetCenterPrice(v3Pool);
 
         // Approve tokens for position manager
@@ -790,7 +786,7 @@ abstract contract LiquidityManagerCore is ERC721TokenReceiver {
         } else {
             // Position already exists: increase liquidity. sqrtP (checkPoolAndGetCenterPrice) above is the
             // pre-flight manipulation gate; anchor the increase's amountMin to slot0 (the execution price) to
-            // avoid the #306.1 dead band, mirroring _decreaseLiquidity.
+            // avoid the TWAP-vs-slot0 dead band, mirroring _decreaseLiquidity.
             (uint160 slot0Sqrt,) = _getPriceAndObservationIndexFromSlot0(v3Pool);
             (liquidity, amounts) = _increaseLiquidity(positionId, amounts, slot0Sqrt);
         }
@@ -1060,10 +1056,11 @@ abstract contract LiquidityManagerCore is ERC721TokenReceiver {
             revert ZeroValue();
         }
 
-        // Pre-flight manipulation gate (fails closed on an unverifiable pool or slot0 > 10% off the TWAP)
+        // Pre-flight manipulation gate (fails closed on an unverifiable pool or slot0 more than
+        // MAX_ALLOWED_DEVIATION off the TWAP)
         checkPoolAndGetCenterPrice(pool);
         // Anchor the liquidity math and amountMin to slot0 (the price the position manager executes at), not the
-        // TWAP center — the entry analog of _decreaseLiquidity's _getExitSqrtPrice; fixes the #306.1 dead band.
+        // TWAP center — the entry analog of _decreaseLiquidity's _getExitSqrtPrice; avoids the TWAP-vs-slot0 dead band.
         (uint160 slot0Sqrt,) = _getPriceAndObservationIndexFromSlot0(pool);
 
         // Approve tokens for position manager

--- a/contracts/pol/LiquidityManagerCore.sol
+++ b/contracts/pol/LiquidityManagerCore.sol
@@ -764,7 +764,10 @@ abstract contract LiquidityManagerCore is ERC721TokenReceiver {
             amounts = _manageUtilityAmounts(tokens, olasBurnRate, true);
         }
 
-        // Check current pool prices
+        // Check current pool prices. NOTE (#324): this gate-verified sqrtP (within 2% of the V3 TWAP) is also the
+        // trusted reference the proposed source-side cross-check would reuse — asserting the V2-removed A:B ratio in
+        // `amounts` matches it — to drop `oracleV2`/`_fairMinAmountsOut` without losing a manipulation gate. The gate
+        // here also guarantees that reference is only trusted on a warmed pool (an unseeded pool's slot0 is stale).
         uint160 sqrtP = checkPoolAndGetCenterPrice(v3Pool);
 
         // Approve tokens for position manager

--- a/contracts/pol/LiquidityManagerSourceBase.sol
+++ b/contracts/pol/LiquidityManagerSourceBase.sol
@@ -38,14 +38,8 @@ abstract contract LiquidityManagerSourceBase is LiquidityManagerCore {
 
     /// @dev Computes manipulation-resistant minimum withdrawal amounts from the constant-product invariant.
     /// @notice `k` (reserve0 * reserve1, or balance0 * balance1) is invariant across swaps, so pairing it with
-    ///         the OLAS TWAP yields fair reserves the removal must at least honor (floored by `maxSlippage`).
-    ///         NOTE: whether this TWAP floor (and therefore `oracleV2` and `maxSlippage`) is needed at all is
-    ///         tracked in issue #324 — a proportional removeLiquidity cannot be sandwiched for a value loss
-    ///         (constant-product convexity, per internal20 R6), so it may be droppable. The proposed replacement
-    ///         keeps a manipulation gate WITHOUT the oracle: cross-check the removed A:B ratio against the V3 pool's
-    ///         gate-verified slot0 (already computed by `checkPoolAndGetCenterPrice` in `convertToV3`), re-tasking
-    ///         `maxSlippage` as the V2↔V3 tolerance. Fork-measured separation (honest 0–20 bps vs a real 50-WETH
-    ///         sandwich at ~4007 bps) is in test/LiquidityManagerV2V3CrossCheckForkETH.t.sol. Read #324 before changing.
+    ///         the OLAS TWAP yields fair reserves the removal must at least honor (floored by `maxSlippage`),
+    ///         making the minimum-out resistant to spot-price manipulation of the source pool.
     /// @param k Constant-product invariant of the source pool (product of the two reserves/balances).
     /// @param token0IsOlas True if `tokens[0]` is OLAS (selects which fair reserve gets the TWAP numerator).
     /// @param liquidity This contract's LP/BPT balance being withdrawn.

--- a/contracts/pol/LiquidityManagerSourceBase.sol
+++ b/contracts/pol/LiquidityManagerSourceBase.sol
@@ -41,7 +41,11 @@ abstract contract LiquidityManagerSourceBase is LiquidityManagerCore {
     ///         the OLAS TWAP yields fair reserves the removal must at least honor (floored by `maxSlippage`).
     ///         NOTE: whether this TWAP floor (and therefore `oracleV2` and `maxSlippage`) is needed at all is
     ///         tracked in issue #324 — a proportional removeLiquidity cannot be sandwiched for a value loss
-    ///         (constant-product convexity, per internal20 R6), so it may be droppable. Read #324 before changing.
+    ///         (constant-product convexity, per internal20 R6), so it may be droppable. The proposed replacement
+    ///         keeps a manipulation gate WITHOUT the oracle: cross-check the removed A:B ratio against the V3 pool's
+    ///         gate-verified slot0 (already computed by `checkPoolAndGetCenterPrice` in `convertToV3`), re-tasking
+    ///         `maxSlippage` as the V2↔V3 tolerance. Fork-measured separation (honest 0–20 bps vs a real 50-WETH
+    ///         sandwich at ~4007 bps) is in test/LiquidityManagerV2V3CrossCheckForkETH.t.sol. Read #324 before changing.
     /// @param k Constant-product invariant of the source pool (product of the two reserves/balances).
     /// @param token0IsOlas True if `tokens[0]` is OLAS (selects which fair reserve gets the TWAP numerator).
     /// @param liquidity This contract's LP/BPT balance being withdrawn.

--- a/contracts/pol/LiquidityManagerUniV2UniV3Bridge.sol
+++ b/contracts/pol/LiquidityManagerUniV2UniV3Bridge.sol
@@ -13,7 +13,7 @@ import {LiquidityManagerBurnViaBridge} from "./LiquidityManagerBurnViaBridge.sol
 /// @dev Converts protocol-owned Uniswap-V2-style liquidity (e.g. Ubeswap on Celo) into a canonical Uniswap V3
 ///      concentrated position on an L2, bridging OLAS to L1 for burning. It is the L2-burn sibling of
 ///      `LiquidityManagerUniV2UniV3` (which burns locally on L1): same UniV2 source + UniV3 target, but the
-///      `BurnViaBridge` mixin instead of the direct L1 `OLAS.burn`. Pure composition of the audited
+///      `BurnViaBridge` mixin instead of the direct L1 `OLAS.burn`. Pure composition of the existing
 ///      UniV2-source, UniV3-target and L2-burn mixins — it declares no logic of its own.
 contract LiquidityManagerUniV2UniV3Bridge is
     LiquidityManagerSourceUniV2,

--- a/docs/lm_source_crosscheck_design.md
+++ b/docs/lm_source_crosscheck_design.md
@@ -41,6 +41,16 @@ token to the treasury** (`convertToV3`'s trailing `_manageUtilityAmounts(tokens,
 are *transferred* to treasury, not burned/lost). Net result: **no value loss** (convexity + leftover retained),
 but a lopsided, inefficient conversion — most POL parked idle in treasury instead of placed in V3.
 
+One step sits between removal and mint that the removal → mint → leftovers walk above skips: when `convertToV3`
+is called with a non-zero `olasBurnRate`, `_manageUtilityAmounts(tokens, olasBurnRate, true)` **burns** that
+rate of the removed OLAS *before* the mint — irreversibly, where leftovers are merely parked. The conclusion
+(no value loss) still holds, for a reason worth stating explicitly rather than leaving implicit: once the
+cross-check exists it reverts the whole transaction, which unwinds the burn atomically, so placing the gate
+*after* the burn is safe. What it does **not** unwind is a *within-tolerance* skew — at a 5% tolerance a
+manipulator can shift the burned OLAS by up to ~5% at swap-fee cost, bounded and value-safe by convexity but
+real, and more relevant the larger the migration's `olasBurnRate`. An **accepted residual**, recorded here
+rather than left for a future reader to find the burn step unconsidered.
+
 ## Proposed replacement — cross-check the V2-removed ratio against the gate-verified V3 slot0
 
 `convertToV3` already computes a trusted price it isn't reusing:

--- a/docs/lm_source_crosscheck_design.md
+++ b/docs/lm_source_crosscheck_design.md
@@ -1,0 +1,108 @@
+# LiquidityManager source-side manipulation gate — oracle → V3-slot0 cross-check (issue #324)
+
+This note captures the design that lets the LiquidityManager drop its per-chain source-side TWAP oracle
+(`oracleV2`) without losing a manipulation gate on the V2/Balancer `removeLiquidity` path. It is the design
+half of issue **#324**; the measurement half is the fork prototype
+`test/LiquidityManagerV2V3CrossCheckForkETH.t.sol`.
+
+## Today
+
+The source mixins (`LiquidityManagerSourceUniV2` / `LiquidityManagerSourceBalancer`) derive a
+manipulation-resistant `minAmountsOut` for the withdrawal from a per-chain TWAP oracle, in
+`LiquidityManagerSourceBase._fairMinAmountsOut` → `IOracle(oracleV2).getTWAP()`. That min-out is:
+
+- the **sole** purpose of the `oracleV2` deployment on every chain, and
+- post-#306.1, the **only live use** of the `liquidityManagerMaxSlippage` deploy parameter (its V3
+  `amount{0,1}Min` uses are vacuous — slot0-anchored).
+
+So the oracle is a standing deployment + "is this oracle still current?" maintenance burden whose only job is
+this one floor.
+
+## Why the floor isn't protecting value
+
+A proportional `removeLiquidity` **cannot be sandwiched for a value loss**. Burning `L` LP at manipulated
+reserves `(RA', RB')` with `RA'·RB' = k` yields a basket worth `L/TS · RB · (m + 1/m)` at the *true* price,
+and `m + 1/m ≥ 2` for any manipulation factor `m`. A skewed pool hands the remover **≥ the fair (balanced)
+value**, never less — the same constant-product convexity proved for the V3 exit in `audits/internal20` R6 /
+vulnerabilities-list #26 (`dV/dPm = (L/2√Pm)(1 − Pt/Pm)`). Removing the floor cannot cause a value loss.
+
+## The residual concern — and why the existing V3-side checks don't cover it
+
+`convertToV3` removes from V2 and, in the **same transaction**, mints the basket into a V3 position. With the
+oracle gone, a V2 pool manipulated to skew `(A, B)` is **not** caught by the V3-side defences, because those
+defend the V3 *pool*, not the incoming basket:
+
+- `MAX_ALLOWED_DEVIATION` (2%) gate (`checkPoolAndGetCenterPrice`) reverts if the V3 pool's slot0 deviates from
+  its own TWAP — it verifies the V3 pool is un-manipulated; it never inspects the `(A, B)` ratio.
+- the mint's `amount{0,1}Min` are slot0-anchored post-#306.1 (they equal what is minted) — vacuous here.
+
+A skewed removal therefore mints what the V3 ratio accepts and **sweeps the excess of the over-represented
+token to the treasury** (`convertToV3`'s trailing `_manageUtilityAmounts(tokens, MAX_BPS, false)` — leftovers
+are *transferred* to treasury, not burned/lost). Net result: **no value loss** (convexity + leftover retained),
+but a lopsided, inefficient conversion — most POL parked idle in treasury instead of placed in V3.
+
+## Proposed replacement — cross-check the V2-removed ratio against the gate-verified V3 slot0
+
+`convertToV3` already computes a trusted price it isn't reusing:
+`sqrtP = checkPoolAndGetCenterPrice(v3Pool)`, gate-proven within 2% of the V3 pool's own TWAP. The V2-removed
+amounts are reserve-proportional, so their ratio `A:B` **is** the V2 spot price. Two pools tracking the same
+OLAS price arbitrage to the same level, hence:
+
+```
+assert | ratio(A:B) − price(V3 slot0) | / price(V3 slot0) ≤ tolerance
+```
+
+This is exactly today's "V2 spot vs a trusted reference" check — with the reference swapped from an **external
+TWAP oracle** to the **V3 pool's own slot0**, which is already on hand and already gate-verified. It:
+
+- **drops the per-chain oracle** (the #324 goal), and
+- **keeps a manipulation gate**, and
+- **re-tasks `maxSlippage`** as the V2↔V3 tolerance instead of retiring it.
+
+### Ratio check, not "small leftover" check
+
+Prefer the input-**ratio** check over a "leftover must be small after mint" check. Leftover size after a
+*concentrated* mint depends on the tick range the scanner picks, not just price, so a leftover test conflates a
+narrow range with manipulation. The `A:B`-vs-slot0 ratio is range-independent.
+
+### Trust precondition (already enforced)
+
+The reference is only meaningful on a **warmed** V3 pool. An empty pool's slot0 is a stale artifact — the
+prototype shows OLAS/WETH V3 on ETH today is unseeded (`liquidity()==0`, slot0 ~9361 bps off the live V2
+price). That is precisely the state the 2% `MAX_ALLOWED_DEVIATION` gate + the runbook pre-warm already reject
+**before** any mint, so the cross-check is never consulted against an untrustworthy reference. The two checks
+**compose**: the gate guarantees the reference is trustworthy; the cross-check guarantees the V2 input matches
+that trustworthy reference.
+
+## Fork evidence (`test/LiquidityManagerV2V3CrossCheckForkETH.t.sol`, ETH mainnet)
+
+| Scenario | Measured divergence | Meaning |
+| --- | --- | --- |
+| Deep dual-live pair WETH/USDC, V2 vs V3 (0.05% / 0.30%) | 20 bps / 0 bps | honest V2↔V3 basis is tiny — the tolerance floor |
+| Honest OLAS removal vs V3 seeded at the true price | 0 bps | honest flow sails through |
+| **Real 50-WETH sandwich on the ~272-WETH OLAS/WETH V2 pool** | **~4007 bps (~40%)** | **cross-check reverts** |
+| Unseeded OLAS/WETH V3 slot0 vs live V2 | ~9361 bps | untrustworthy reference — rejected by the 2% gate first |
+
+Honest flow lands at 0–20 bps; a real manipulation lands ~40%. Any tolerance in the low single-digit-percent
+range separates them cleanly.
+
+## Tolerance sizing — the one thing to measure before shipping
+
+The deep-pair basis (≤20 bps) is a *lower bound*. OLAS pools are thinner, so their honest V2↔V3 basis will sit
+above that. Before committing the production tolerance, measure the **real OLAS V2↔V3 basis once the target V3
+pool is seeded** (i.e. after the migration's own pre-warm), and set `maxSlippage` above that honest basis with
+margin, but well below the manipulation regime (whole percent). This is the same class of tuning the current
+`maxSlippage` already required.
+
+## Affected code (when implemented)
+
+- `contracts/pol/LiquidityManagerCore.sol` — `convertToV3` would pass the already-computed `sqrtP` into the
+  source-side check.
+- `contracts/pol/LiquidityManagerSourceBase.sol` — `_fairMinAmountsOut` (+ `oracleV2`) replaced by the ratio
+  cross-check; `IOracle` import dropped.
+- `contracts/pol/LiquidityManagerSourceUniV2.sol` / `LiquidityManagerSourceBalancer.sol` — call sites updated.
+- Deploy globals / scripts — `uniswapPriceOracleAddress` / `balancerPriceOracleAddress` / `oracleV2` constructor
+  arg retired; `liquidityManagerMaxSlippage` retained (re-tasked).
+
+This is a security-relevant change on a security-critical path — it needs review + before/after fork tests, per
+#324.

--- a/test/LiquidityManagerV2V3CrossCheckForkETH.t.sol
+++ b/test/LiquidityManagerV2V3CrossCheckForkETH.t.sol
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {FixedPointMathLib} from "../lib/solmate/src/utils/FixedPointMathLib.sol";
+import {Test} from "forge-std/Test.sol";
+
+interface IERC20 {
+    function balanceOf(address account) external view returns (uint256);
+    function approve(address spender, uint256 amount) external returns (bool);
+}
+
+interface IUniV2Pair {
+    function getReserves() external view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast);
+    function token0() external view returns (address);
+    function token1() external view returns (address);
+}
+
+interface IUniV2Router {
+    function swapExactTokensForTokens(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external returns (uint256[] memory amounts);
+}
+
+interface IUniV3Pool {
+    function slot0()
+        external
+        view
+        returns (uint160 sqrtPriceX96, int24 tick, uint16 obsIndex, uint16 obsCard, uint16 obsCardNext, uint8 feeProtocol, bool unlocked);
+    function liquidity() external view returns (uint128);
+    function token0() external view returns (address);
+}
+
+/// @title LiquidityManager source-side manipulation cross-check — ETH fork prototype (issue #324)
+/// @author Aleksandr Kuperman - <aleksandr.kuperman@valory.xyz>
+/// @dev PROTOTYPE / MEASUREMENT harness. Nothing here is wired into the production contracts yet — it exists to
+///      de-risk the design proposed in issue #324 before a tolerance is committed. It reads live mainnet state and
+///      exercises the proposed check as a pure helper (`_ratioDivergenceBps`).
+///
+/// ─────────────────────────────────────────────────────────────────────────────────────────────────────────────
+/// BACKGROUND — what #324 wants to drop, and why it is safe to
+/// ─────────────────────────────────────────────────────────────────────────────────────────────────────────────
+/// The source side of the LiquidityManager (`_checkTokensAndRemoveLiquidityV2` in the UniV2 / Balancer source
+/// mixins) currently derives a manipulation-resistant `minAmountsOut` from a per-chain TWAP oracle
+/// (`LiquidityManagerSourceBase._fairMinAmountsOut` -> `IOracle(oracleV2).getTWAP()`). That min-out is the SOLE
+/// purpose of the `oracleV2` deployment and — post-#306.1 — the only live use of the `liquidityManagerMaxSlippage`
+/// deploy parameter. #324 proposes dropping it, because a proportional `removeLiquidity` CANNOT be sandwiched for a
+/// value loss: burning `L` LP at manipulated reserves `(RA', RB')` with `RA'·RB' = k` yields a basket worth
+/// `L/TS · RB · (m + 1/m)` at the true price, and `m + 1/m ≥ 2` for any manipulation `m` — i.e. ALWAYS ≥ the fair
+/// (balanced) value. A skewed pool hands the remover MORE value at the true price, never less (constant-product
+/// convexity; the same result proved for the V3 exit in audits/internal20 R6 / vulnerabilities-list #26).
+///
+/// ─────────────────────────────────────────────────────────────────────────────────────────────────────────────
+/// THE RESIDUAL CONCERN, AND WHY THE V3-SIDE CHECKS DON'T COVER IT
+/// ─────────────────────────────────────────────────────────────────────────────────────────────────────────────
+/// `convertToV3` removes from V2 and, in the SAME tx, mints the basket into a V3 position. With the oracle gone, a
+/// V2 pool manipulated to skew `(A, B)` is not caught by the V3-side defences, because those defend the V3 POOL,
+/// not the incoming basket:
+///   • `MAX_ALLOWED_DEVIATION` (2%) gate (`checkPoolAndGetCenterPrice`) reverts if the V3 pool's slot0 deviates
+///     from its own TWAP — it verifies the V3 pool is un-manipulated; it never inspects the `(A, B)` ratio.
+///   • the mint's `amount{0,1}Min` are slot0-anchored post-#306.1 (they equal what is minted) — vacuous here.
+/// So a skewed removal mints what the V3 ratio accepts and sweeps the excess of the over-represented token to the
+/// treasury (see `convertToV3`'s trailing `_manageUtilityAmounts(tokens, MAX_BPS, false)` — leftovers are
+/// TRANSFERRED to treasury, not burned/lost). Net: no value loss (convexity + leftover retained), but a lopsided,
+/// inefficient conversion — most POL parked idle in treasury instead of placed in V3.
+///
+/// ─────────────────────────────────────────────────────────────────────────────────────────────────────────────
+/// THE PROPOSED REPLACEMENT — cross-check the V2-removed ratio against the gate-verified V3 slot0
+/// ─────────────────────────────────────────────────────────────────────────────────────────────────────────────
+/// `convertToV3` ALREADY computes a trusted price it isn't reusing: `sqrtP = checkPoolAndGetCenterPrice(v3Pool)`,
+/// gate-proven within 2% of the V3 pool's own TWAP. The V2-removed amounts are reserve-proportional, so their
+/// ratio `A:B` IS the V2 spot price. Two pools tracking the same OLAS price arbitrage to the same level, therefore:
+///
+///     assert | ratio(A:B) − price(V3 slot0) | / price(V3 slot0) ≤ tolerance
+///
+/// is exactly today's "V2 spot vs a trusted reference" check — with the reference swapped from an external TWAP
+/// oracle to the V3 pool's own slot0, which is already on hand and already gate-verified. This DROPS the per-chain
+/// oracle (the #324 goal) yet KEEPS a manipulation gate, and re-tasks `maxSlippage` as the V2↔V3 tolerance rather
+/// than retiring it. Prefer this input-RATIO check over a "leftover must be small" check: leftover size after a
+/// CONCENTRATED mint depends on the tick range the scanner picks, not just price, so it conflates a narrow range
+/// with manipulation; the `A:B`-vs-slot0 ratio is range-independent.
+///
+/// TRUST PRECONDITION (important, and already enforced): the reference is only meaningful on a WARMED V3 pool. An
+/// empty pool's slot0 is a stale artifact — see `test_olasV3Pool_unseeded_referenceIsStale` (OLAS/WETH V3 on ETH is
+/// unseeded today: `liquidity()==0`, slot0 ~93% off the live V2 price). That is precisely the state the 2%
+/// `MAX_ALLOWED_DEVIATION` gate + the runbook pre-warm already reject BEFORE any mint, so the cross-check is never
+/// consulted against an untrustworthy reference. The two checks compose: the gate guarantees the reference is
+/// trustworthy; the cross-check guarantees the V2 input matches that trustworthy reference.
+///
+/// ─────────────────────────────────────────────────────────────────────────────────────────────────────────────
+/// WHAT THIS TEST MEASURES / DEMONSTRATES (self-skips off an ETH mainnet fork)
+/// ─────────────────────────────────────────────────────────────────────────────────────────────────────────────
+///   1. test_deepPairBasis_isTiny            — natural V2↔V3 basis on a deep, heavily-arbitraged pair (WETH/USDC):
+///                                             MEASURED 0–20 bps. Honest pools agree to <0.2%, so any workable OLAS
+///                                             tolerance (whole percent) clears honest flow with room to spare.
+///   2. test_olasV3Pool_unseeded_referenceIsStale — the trust precondition, shown live: OLAS/WETH V3 unseeded,
+///                                             slot0 useless as a reference (MEASURED ~9361 bps off V2) → the exact
+///                                             state the 2% gate rejects.
+///   3. test_crossCheck_catchesV2Manipulation — a REAL sandwich swap on the live OLAS/WETH V2 pair (50 WETH into a
+///                                             ~272 WETH pool) moves the removed `A:B` ratio MEASURED ~4007 bps
+///                                             (~40%) off the pre-trade (true) price → the cross-check would revert,
+///                                             vs 0 bps for the honest baseline in the same test.
+///   4. test_crossCheck_passesHonestRemoval  — an un-manipulated removal vs a reference seeded at the true price
+///                                             diverges 0 bps → honest flow is untouched.
+contract LiquidityManagerV2V3CrossCheckForkETHTest is Test {
+    // OLAS/WETH — OLAS is live on Uniswap V2 (deep) but its V3 pool is unseeded (that's what POL migration seeds).
+    address internal constant OLAS = 0x0001A500A6B18995B03f44bb040A5fFc28E45CB0;
+    address internal constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+    address internal constant OLAS_WETH_V2 = 0x09D1d767eDF8Fa23A64C51fa559E0688E526812F;
+    address internal constant OLAS_WETH_V3_1PCT = 0x18f7B33172F5150949EeF05EbB3b5D4Fe245f391; // fee 10000
+    address internal constant ROUTER_V2 = 0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D;
+
+    // WETH/USDC — live on BOTH Uniswap V2 and Uniswap V3; a proxy for the natural V2↔V3 basis on a deep pair.
+    address internal constant WETH_USDC_V2 = 0xB4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc;
+    address internal constant WETH_USDC_V3_005PCT = 0x88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640; // fee 500
+    address internal constant WETH_USDC_V3_030PCT = 0x8ad599c3A0ff1De082011EFDDc58f1908eb6e6D8; // fee 3000
+
+    uint256 internal constant Q96 = 0x1000000000000000000000000; // 2**96
+
+    function setUp() public {
+        // Self-skip when not on an ETH mainnet fork (chainId 1). Run with:
+        //   forge test -f $FORK_ETH_NODE_URL --mc LiquidityManagerV2V3CrossCheckForkETH -vv
+        if (block.chainid != 1) {
+            vm.skip(true);
+        }
+    }
+
+    // ─── proposed cross-check, prototyped as pure helpers (mirror what production would inline) ───
+
+    /// @dev V3 price (token1 per token0), 1e18-scaled, from a sqrtPriceX96. Overflow-safe for realistic sqrtP:
+    ///      staged mulDiv keeps every intermediate under 2**256 (sqrtP² fits for OLAS/WETH ~1e54 and WETH/USDC ~3e66).
+    function _priceFromSqrt(uint160 sqrtP) internal pure returns (uint256) {
+        uint256 sp = uint256(sqrtP);
+        // (sqrtP² / 2**96) — this is price·2**96
+        uint256 priceX96 = FixedPointMathLib.mulDivDown(sp, sp, Q96);
+        // ·1e18 / 2**96 — drops the last 2**96 and rescales to 1e18
+        return FixedPointMathLib.mulDivDown(priceX96, 1e18, Q96);
+    }
+
+    /// @dev Divergence in bps between the V2-removed ratio (amount1/amount0 == V2 spot, amounts being
+    ///      reserve-proportional) and the gate-verified V3 slot0 price. This is the quantity the proposed
+    ///      `require(divergence <= maxSlippage)` would gate on.
+    function _ratioDivergenceBps(uint256 amount0, uint256 amount1, uint160 sqrtP) internal pure returns (uint256) {
+        uint256 pV2 = FixedPointMathLib.mulDivDown(amount1, 1e18, amount0); // token1 per token0
+        uint256 pV3 = _priceFromSqrt(sqrtP);
+        uint256 diff = pV2 > pV3 ? pV2 - pV3 : pV3 - pV2;
+        return (diff * 10000) / pV3;
+    }
+
+    /// @dev sqrtPriceX96 corresponding to a reserve pair — the price a V3 pool seeded at that pair's spot would show.
+    function _sqrtFromReserves(uint256 reserve0, uint256 reserve1) internal pure returns (uint160) {
+        // sqrtP = sqrt(reserve1/reserve0)·2**96 = sqrt(reserve1·1e18/reserve0)·2**96/1e9  (staged to avoid overflow)
+        uint256 price1e18 = FixedPointMathLib.mulDivDown(reserve1, 1e18, reserve0);
+        uint256 sqrt1e9 = FixedPointMathLib.sqrt(price1e18); // == sqrt(price)·1e9
+        return uint160(FixedPointMathLib.mulDivDown(sqrt1e9, Q96, 1e9));
+    }
+
+    function _reserves(address pair) internal view returns (uint256 r0, uint256 r1) {
+        (uint112 a, uint112 b,) = IUniV2Pair(pair).getReserves();
+        (r0, r1) = (uint256(a), uint256(b));
+    }
+
+    function _sqrt0(address pool) internal view returns (uint160 sqrtP) {
+        (sqrtP,,,,,,) = IUniV3Pool(pool).slot0();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────────────────────────────────
+    // 1. Natural V2↔V3 basis on a deep pair: honest pools agree to <0.2% → tolerance has ample headroom.
+    // ─────────────────────────────────────────────────────────────────────────────────────────────────────────
+    function test_deepPairBasis_isTiny() public {
+        (uint256 r0, uint256 r1) = _reserves(WETH_USDC_V2);
+
+        uint256 basis005 = _ratioDivergenceBps(r0, r1, _sqrt0(WETH_USDC_V3_005PCT));
+        uint256 basis030 = _ratioDivergenceBps(r0, r1, _sqrt0(WETH_USDC_V3_030PCT));
+        emit log_named_uint("WETH/USDC V2 vs V3 0.05% basis (bps)", basis005);
+        emit log_named_uint("WETH/USDC V2 vs V3 0.30% basis (bps)", basis030);
+
+        // A deep, heavily-arbitraged pair keeps its V2↔V3 basis well under 1% — the honest floor a tolerance
+        // must clear. OLAS being thinner will sit above this, but the mechanism (honest << manipulated) holds.
+        assertLt(basis005, 100, "deep-pair V2<->V3 basis unexpectedly wide");
+        assertLt(basis030, 100, "deep-pair V2<->V3 basis unexpectedly wide");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────────────────────────────────
+    // 2. Trust precondition, live: an unseeded V3 pool's slot0 is a stale artifact — the state the 2% gate rejects.
+    // ─────────────────────────────────────────────────────────────────────────────────────────────────────────
+    function test_olasV3Pool_unseeded_referenceIsStale() public {
+        // OLAS/WETH V3 has no in-range liquidity: nothing arbitrages its slot0 toward the true price.
+        assertEq(IUniV3Pool(OLAS_WETH_V3_1PCT).liquidity(), 0, "assumed-unseeded OLAS/WETH V3 now has liquidity");
+        assertEq(IUniV3Pool(OLAS_WETH_V3_1PCT).token0(), OLAS, "unexpected V3 token0 ordering");
+
+        (uint256 r0, uint256 r1) = _reserves(OLAS_WETH_V2);
+        uint256 divergence = _ratioDivergenceBps(r0, r1, _sqrt0(OLAS_WETH_V3_1PCT));
+        emit log_named_uint("OLAS/WETH live-V2 vs unseeded-V3 slot0 divergence (bps)", divergence);
+
+        // The stale slot0 sits absurdly far from the live V2 price (~9000+ bps). Cross-checking against THIS would
+        // be meaningless — which is why the design only ever runs the cross-check AFTER the 2% MAX_ALLOWED_DEVIATION
+        // gate (checkPoolAndGetCenterPrice) + the runbook pre-warm have accepted the pool. An unseeded pool fails
+        // that gate and never reaches the mint, let alone the cross-check.
+        assertGt(divergence, 200, "unseeded V3 slot0 unexpectedly near the live V2 price");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────────────────────────────────
+    // 3. A real sandwich on the live OLAS/WETH V2 pair moves the removed ratio far past any sane tolerance.
+    // ─────────────────────────────────────────────────────────────────────────────────────────────────────────
+    function test_crossCheck_catchesV2Manipulation() public {
+        (uint256 r0Before, uint256 r1Before) = _reserves(OLAS_WETH_V2);
+
+        // Reference = the true price a warmed V3 pool reflects. The attacker touches only V2 within this tx, so the
+        // V3 reference stays at the pre-trade price (cross-pool arb is not instant intra-tx).
+        uint160 sqrtRef = _sqrtFromReserves(r0Before, r1Before);
+
+        // Honest baseline: removed ratio at the un-manipulated reserves matches the reference ~exactly.
+        uint256 honest = _ratioDivergenceBps(r0Before, r1Before, sqrtRef);
+        emit log_named_uint("honest removed-ratio vs reference (bps)", honest);
+        assertLt(honest, 50, "reserve-derived reference should match its own reserves");
+
+        // Attacker front-runs: dump 50 WETH into the V2 pair (pool holds ~272 WETH → a large but plausible sandwich).
+        uint256 attackWeth = 50 ether;
+        deal(WETH, address(this), attackWeth);
+        IERC20(WETH).approve(ROUTER_V2, attackWeth);
+        address[] memory path = new address[](2);
+        path[0] = WETH;
+        path[1] = OLAS;
+        IUniV2Router(ROUTER_V2).swapExactTokensForTokens(attackWeth, 0, path, address(this), block.timestamp + 1);
+
+        // Now a removal would pull this skewed basket; its ratio is the post-trade reserve ratio.
+        (uint256 r0After, uint256 r1After) = _reserves(OLAS_WETH_V2);
+        uint256 manipulated = _ratioDivergenceBps(r0After, r1After, sqrtRef);
+        emit log_named_uint("manipulated removed-ratio vs reference (bps)", manipulated);
+
+        // The skewed removal is worth >= fair value at the true price (convexity — no loss). But its RATIO is now
+        // wildly off the trusted V3 reference, so the proposed cross-check catches it and reverts — preventing the
+        // lopsided, treasury-parking conversion described in the header. A few-hundred-bps tolerance rejects it
+        // outright, while the honest case above passes with <50 bps.
+        assertGt(manipulated, 500, "cross-check failed to flag a real V2 manipulation");
+        assertGt(manipulated, honest * 10, "manipulation not clearly separated from honest flow");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────────────────────────────────
+    // 4. An honest removal against a reference seeded at the true price passes with ~0 divergence.
+    // ─────────────────────────────────────────────────────────────────────────────────────────────────────────
+    function test_crossCheck_passesHonestRemoval() public {
+        (uint256 r0, uint256 r1) = _reserves(OLAS_WETH_V2);
+        uint160 sqrtRef = _sqrtFromReserves(r0, r1); // V3 seeded at the true OLAS price
+        uint256 divergence = _ratioDivergenceBps(r0, r1, sqrtRef);
+        emit log_named_uint("honest OLAS removal vs seeded-at-true-price V3 (bps)", divergence);
+        assertLt(divergence, 50, "honest removal should sail through the cross-check");
+    }
+}


### PR DESCRIPTION
## What this is

The **design + measurement half of #324** — evaluating whether the source-side TWAP oracle (`oracleV2`) on the V2/Balancer `removeLiquidity` path can be dropped. No production wiring yet: this adds a **fork prototype**, a **design note**, and **NatSpec** capturing the answer, so a tolerance can be committed on evidence rather than a guess. Follow-up PR would wire the check into `convertToV3` + retire `oracleV2`/`_fairMinAmountsOut`.

## The question behind #324

The oracle's only job is a manipulation-resistant `minAmountsOut` floor on the withdrawal (`_fairMinAmountsOut`). But a proportional `removeLiquidity` **cannot be sandwiched for a value loss** — burning `L` LP at manipulated reserves yields a basket worth `L/TS·RB·(m + 1/m)` at the true price, and `m + 1/m ≥ 2` always (constant-product convexity; same result as internal20 R6 / vuln-list #26). So the floor isn't protecting value, and the oracle is pure deployment + "is this oracle still current?" maintenance surface.

## The residual concern — and why the V3-side checks don't cover it

`convertToV3` removes from V2 and mints into V3 in the **same tx**. With the oracle gone, a **V2 pool manipulated to skew `(A, B)`** is *not* caught by the V3-side defences, because those guard the V3 **pool**, not the incoming basket:

- the 2% `MAX_ALLOWED_DEVIATION` gate (`checkPoolAndGetCenterPrice`) verifies the V3 pool vs its own TWAP — it never inspects the `(A, B)` ratio;
- the mint's `amount{0,1}Min` are slot0-anchored post-#306.1 (vacuous).

A skewed removal mints what the V3 ratio accepts and **sweeps the excess to the treasury** (`_manageUtilityAmounts(tokens, MAX_BPS, false)` — leftovers are *transferred*, not burned). Net: **no value loss** (convexity + leftover retained), but a **lopsided, inefficient conversion** — POL parked idle in treasury instead of placed in V3.

## Proposed replacement — reuse the price we already trust

`convertToV3` already computes a gate-verified `sqrtP = checkPoolAndGetCenterPrice(v3Pool)` (within 2% of the V3 TWAP) and doesn't reuse it. The V2-removed amounts are reserve-proportional, so their ratio `A:B` **is** the V2 spot. Two pools tracking the same OLAS price arbitrage together, so:

```
assert | ratio(A:B) − price(V3 slot0) | / price(V3 slot0) ≤ tolerance
```

This is today's "V2 spot vs a trusted reference" check with the reference swapped from an **external oracle** to the **V3 slot0 already on hand** — dropping the per-chain oracle while **keeping a manipulation gate** and **re-tasking `maxSlippage`** as the V2↔V3 tolerance.

- **Ratio, not "small leftover":** leftover size after a concentrated mint depends on the scanner's tick range, not just price — it conflates a narrow range with manipulation. The `A:B`-vs-slot0 ratio is range-independent.
- **Trust precondition, already enforced:** the reference is only meaningful on a *warmed* pool. An empty pool's slot0 is stale — exactly what the 2% gate + runbook pre-warm reject before any mint. The two checks **compose**: the gate makes the reference trustworthy; the cross-check makes the V2 input match it.

## Fork evidence (`test/LiquidityManagerV2V3CrossCheckForkETH.t.sol`)

| Scenario | Measured | Meaning |
| --- | --- | --- |
| Deep pair WETH/USDC, V2 vs V3 (0.05% / 0.30%) | **20 / 0 bps** | honest V2↔V3 basis is tiny → tolerance floor |
| Honest OLAS removal vs V3 seeded at true price | **0 bps** | honest flow untouched |
| **Real 50-WETH sandwich on ~272-WETH OLAS/WETH V2** | **~4007 bps (~40%)** | **cross-check reverts** |
| Unseeded OLAS/WETH V3 slot0 vs live V2 | **~9361 bps** | untrustworthy reference — 2% gate rejects it first |

Honest 0–20 bps vs manipulated ~40% — any low-single-digit-percent tolerance separates them cleanly.

## The one open sizing question

The deep-pair basis (≤20 bps) is a *lower bound*; thinner OLAS pools sit above it. Before shipping the production tolerance, **measure the real OLAS V2↔V3 basis once the target V3 pool is seeded** (post pre-warm) and set `maxSlippage` above that honest basis, below the manipulation regime — the same tuning the current `maxSlippage` already needed.

## Files
- `test/LiquidityManagerV2V3CrossCheckForkETH.t.sol` — ETH-fork prototype (long-form rationale in header)
- `docs/lm_source_crosscheck_design.md` — design note
- `contracts/pol/LiquidityManagerCore.sol`, `LiquidityManagerSourceBase.sol` — NatSpec pointers (no logic change)
- `CLAUDE.md` — fork-test command

Run: `forge test -f $FORK_ETH_NODE_URL --mc LiquidityManagerV2V3CrossCheckForkETH -vv`

Refs #324.

---

### Also in this PR — production-comment hygiene (commit 2)

Deployed contracts must be self-contained: they can't resolve GitHub issues/PRs/audit findings on-chain, so those references don't belong in NatSpec/inline comments (tests and `docs/` are fine). Rewrote the LiquidityManager comments that carried such tags — `#306.1`, `VL#15`, `internal20 R6`, `#324`, "audited", and a test-file path — into self-contained descriptions of the actual mechanism. Comment-only, no bytecode change; verified the contract diff touches no executable lines.
