### PR TITLE
docs(runbook): schedule removal of the #322 standing-red exemption

### DIFF
--- a/docs/dispenser_migration_runbook_public.md
+++ b/docs/dispenser_migration_runbook_public.md
@@ -135,6 +135,7 @@ The Dispenser rework changed several ABIs. Regenerate at redeploy so downstream 
 - **`abis/<ver>/Dispenser.json`** — the 3-arg constructor `(olas, tokenomics, retainer)`, the new `initialize` / `changeManagers(address,address)` / `changeImplementation`, and the `calculateStakingIncentives` return tuple that now includes the sparse `zeroWeightEpochs[]`.
 - **`abis/<ver>/DefaultTargetDispenserL2.json`** (and every chain variant) — the 4-arg `Migrated(address,address,uint256,uint256)`. Any indexer/subgraph keyed on the old 3-arg topic0 must handle both during the cutover.
 - **`docs/configuration.json`** — the new `dispenserProxyAddress` and every repointed address, updated **only after** the on-chain rewiring is complete.
+- **`scripts/audit_chains/audit_contracts_setup.js` — delete the standing-red exemption.** `checkBytecode`'s Tier-1 length mismatch is blocking (issue #322), and the script carries a dated `DELIBERATE STANDING-RED DECISION (2026-08)` comment saying the audit is *expected* to `exit(1)` while several deployed implementations still predate the in-repo code (the mainnet / Optimism / Base LiquidityManager impls and the proxied Dispenser). Once an implementation is redeployed and `configuration.json` is repointed above, that contract should go green — **remove the comment in the same PR**, once the last of them clears. A stale "expected red" note is worse than none: it keeps excusing failures after the reason for them has gone.
 
 ## 8. Rollback / risk notes
 

--- a/docs/liquidity_migration_runbook.md
+++ b/docs/liquidity_migration_runbook.md
@@ -232,6 +232,11 @@ separate source-side oracle to warm — the V2 exit is gated by the ratio cross-
 
 ---
 
+> **After the LM implementations are redeployed:** the chain-audit script carries a dated standing-red
+> exemption (issue #322) stating it is *expected* to `exit(1)` while the deployed LM impls predate the
+> in-repo code. Once they are redeployed and `docs/configuration.json` is repointed, drop that comment —
+> see "Release artifacts to regenerate" in `dispenser_migration_runbook_public.md`.
+
 ## 6. Quick checklist (per chain, before submitting `convertToV3`)
 
 - [ ] **Fixed `LiquidityManager*` implementation live on the proxy** (`changeImplementation`) — before any


### PR DESCRIPTION
Follow-up to #328, which made `checkBytecode`'s Tier-1 length mismatch blocking (issue #322) and recorded a dated `DELIBERATE STANDING-RED DECISION (2026-08)` comment stating the audit is *expected* to `exit(1)` until the POL/Dispenser redeploys land.

That comment currently has no owner. Once #322 closes, nothing tracks removing it — and a stale "expected red" note is worse than none, because it keeps excusing failures after the reason for them has gone. This puts its removal on the release checklist instead of leaving it to an issue, on the reasoning that deleting a comment needs no analysis, only for someone to do it at a step they are already performing.

**Two places, because the redeploys happen on two sides:**

- **`dispenser_migration_runbook_public.md`** → "Release artifacts to regenerate (part of the release checklist, not optional)", immediately after the `configuration.json` repoint. That list already spans both surfaces and is the step where someone is editing exactly this. Notes that each contract goes green as its implementation is redeployed, and the comment comes out with the last one.
- **`liquidity_migration_runbook.md`** → a pointer just before the per-chain checklist, since the **LM implementations are redeployed on the POL side**, not with the Dispenser. Whoever performs only that half would otherwise never see the Dispenser runbook's list.

Documentation only — no contract, script or config change. `check_pol_reconciliation.js` still passes (exit 0).

Closes #322: the mechanism landed in #328; this schedules the one follow-through it created.
