### PR TITLE
fix: migration proposals must carry over withheldAmount, not the OLAS balance

### DIFF
--- a/scripts/proposals/proposal_11_migrate_l2_dispenser_mode.js
+++ b/scripts/proposals/proposal_11_migrate_l2_dispenser_mode.js
@@ -31,14 +31,6 @@ async function main() {
     const optimismMessengerABI = parsedFile["abi"];
     const optimismMessenger = new ethers.Contract(optimismMessengerAddress, optimismMessengerABI, networkProvider);
 
-    // OLAS address on Mode
-    const olasAddress = parsedData.olasAddress;
-    const tokenJSON = "artifacts/contracts/test/ERC20Token.sol/ERC20Token.json";
-    contractFromJSON = fs.readFileSync(tokenJSON, "utf8");
-    parsedFile = JSON.parse(contractFromJSON);
-    const tokenABI = parsedFile["abi"];
-    const olas = new ethers.Contract(olasAddress, tokenABI, networkProvider);
-
     // Get all the necessary contract addresses
     const oldTargetDispenserL2Address = "0xc40C79C275F3fA1F3f4c723755C81ED2D53A8D81";
     const targetDispenserL2Address = parsedData.modeTargetDispenserL2Address;
@@ -74,8 +66,11 @@ async function main() {
     //    [["0x5fc25f50e96857373c64dc0edb1abcbed4587e91"], ["1597983869041054358564"], "0xe16c2d52963fd5d073b1f3907986b0a183c6e39399e5d8ef866c954b73886d72"]);
     //rawPayload = targetDispenserL2.interface.encodeFunctionData("processDataMaintenance", [dataToProcess]);
 
-    const olasBalance = await olas.balanceOf(oldTargetDispenserL2Address);
-    rawPayload = targetDispenserL2.interface.encodeFunctionData("updateWithheldAmountMaintenance", [olasBalance]);
+    // The replacement dispenser must inherit the OLD dispenser's stored withheldAmount, which is the
+    // amount L1 may still re-use. It is NOT the OLAS balance: migrate() moves the full balance, which
+    // also covers funds that were never withheld, and it leaves withheldAmount itself untouched.
+    const withheldAmount = await oldTargetDispenserL2.withheldAmount();
+    rawPayload = targetDispenserL2.interface.encodeFunctionData("updateWithheldAmountMaintenance", [withheldAmount]);
     payload = ethers.utils.arrayify(rawPayload);
     data += ethers.utils.solidityPack(
         ["address", "uint96", "uint32", "bytes"],

--- a/scripts/proposals/proposal_18_migrate_l2_dispenser_optimism.js
+++ b/scripts/proposals/proposal_18_migrate_l2_dispenser_optimism.js
@@ -31,14 +31,6 @@ async function main() {
     const optimismMessengerABI = parsedFile["abi"];
     const optimismMessenger = new ethers.Contract(optimismMessengerAddress, optimismMessengerABI, networkProvider);
 
-    // OLAS address on Optimism
-    const olasAddress = parsedData.olasAddress;
-    const tokenJSON = "artifacts/contracts/test/ERC20Token.sol/ERC20Token.json";
-    contractFromJSON = fs.readFileSync(tokenJSON, "utf8");
-    parsedFile = JSON.parse(contractFromJSON);
-    const tokenABI = parsedFile["abi"];
-    const olas = new ethers.Contract(olasAddress, tokenABI, networkProvider);
-
     // Get all the necessary contract addresses
     const oldTargetDispenserL2Address = "0x04b0007b2aFb398015B76e5f22993a1fddF83644";
     const targetDispenserL2Address = parsedData.optimismTargetDispenserL2Address;
@@ -66,9 +58,12 @@ async function main() {
         [target, value, payload.length, payload]
     ).slice(2);
 
-    const olasBalance = await olas.balanceOf(oldTargetDispenserL2Address);
+    // The replacement dispenser must inherit the OLD dispenser's stored withheldAmount, which is the
+    // amount L1 may still re-use. It is NOT the OLAS balance: migrate() moves the full balance, which
+    // also covers funds that were never withheld, and it leaves withheldAmount itself untouched.
+    const withheldAmount = await oldTargetDispenserL2.withheldAmount();
     target = targetDispenserL2Address;
-    rawPayload = targetDispenserL2.interface.encodeFunctionData("updateWithheldAmountMaintenance", [olasBalance]);
+    rawPayload = targetDispenserL2.interface.encodeFunctionData("updateWithheldAmountMaintenance", [withheldAmount]);
     payload = ethers.utils.arrayify(rawPayload);
     data += ethers.utils.solidityPack(
         ["address", "uint96", "uint32", "bytes"],

--- a/scripts/proposals/proposal_19_migrate_l2_dispenser_base.js
+++ b/scripts/proposals/proposal_19_migrate_l2_dispenser_base.js
@@ -31,14 +31,6 @@ async function main() {
     const optimismMessengerABI = parsedFile["abi"];
     const optimismMessenger = new ethers.Contract(optimismMessengerAddress, optimismMessengerABI, networkProvider);
 
-    // OLAS address on Base
-    const olasAddress = parsedData.olasAddress;
-    const tokenJSON = "artifacts/contracts/test/ERC20Token.sol/ERC20Token.json";
-    contractFromJSON = fs.readFileSync(tokenJSON, "utf8");
-    parsedFile = JSON.parse(contractFromJSON);
-    const tokenABI = parsedFile["abi"];
-    const olas = new ethers.Contract(olasAddress, tokenABI, networkProvider);
-
     // Get all the necessary contract addresses
     const oldTargetDispenserL2Address = "0xcDdD9D9ABaB36fFa882530D69c73FeE5D4001C2d";
     const targetDispenserL2Address = parsedData.baseTargetDispenserL2Address;
@@ -66,9 +58,12 @@ async function main() {
         [target, value, payload.length, payload]
     ).slice(2);
 
-    const olasBalance = await olas.balanceOf(oldTargetDispenserL2Address);
+    // The replacement dispenser must inherit the OLD dispenser's stored withheldAmount, which is the
+    // amount L1 may still re-use. It is NOT the OLAS balance: migrate() moves the full balance, which
+    // also covers funds that were never withheld, and it leaves withheldAmount itself untouched.
+    const withheldAmount = await oldTargetDispenserL2.withheldAmount();
     target = targetDispenserL2Address;
-    rawPayload = targetDispenserL2.interface.encodeFunctionData("updateWithheldAmountMaintenance", [olasBalance]);
+    rawPayload = targetDispenserL2.interface.encodeFunctionData("updateWithheldAmountMaintenance", [withheldAmount]);
     payload = ethers.utils.arrayify(rawPayload);
     data += ethers.utils.solidityPack(
         ["address", "uint96", "uint32", "bytes"],

--- a/scripts/proposals/proposal_20_migrate_l2_dispenser_gnosis.js
+++ b/scripts/proposals/proposal_20_migrate_l2_dispenser_gnosis.js
@@ -31,14 +31,6 @@ async function main() {
     const homeMediatorABI = parsedFile["abi"];
     const homeMediator = new ethers.Contract(homeMediatorAddress, homeMediatorABI, networkProvider);
 
-    // OLAS address on Gnosis
-    const olasAddress = parsedData.olasAddress;
-    const tokenJSON = "artifacts/contracts/test/ERC20Token.sol/ERC20Token.json";
-    contractFromJSON = fs.readFileSync(tokenJSON, "utf8");
-    parsedFile = JSON.parse(contractFromJSON);
-    const tokenABI = parsedFile["abi"];
-    const olas = new ethers.Contract(olasAddress, tokenABI, networkProvider);
-
     // Get all the necessary contract addresses
     const oldTargetDispenserL2Address = "0x67722c823010CEb4BED5325fE109196C0f67D053";
     const targetDispenserL2Address = parsedData.gnosisTargetDispenserL2Address;
@@ -66,9 +58,12 @@ async function main() {
         [target, value, payload.length, payload]
     ).slice(2);
 
-    const olasBalance = await olas.balanceOf(oldTargetDispenserL2Address);
+    // The replacement dispenser must inherit the OLD dispenser's stored withheldAmount, which is the
+    // amount L1 may still re-use. It is NOT the OLAS balance: migrate() moves the full balance, which
+    // also covers funds that were never withheld, and it leaves withheldAmount itself untouched.
+    const withheldAmount = await oldTargetDispenserL2.withheldAmount();
     target = targetDispenserL2Address;
-    rawPayload = targetDispenserL2.interface.encodeFunctionData("updateWithheldAmountMaintenance", [olasBalance]);
+    rawPayload = targetDispenserL2.interface.encodeFunctionData("updateWithheldAmountMaintenance", [withheldAmount]);
     payload = ethers.utils.arrayify(rawPayload);
     data += ethers.utils.solidityPack(
         ["address", "uint96", "uint32", "bytes"],


### PR DESCRIPTION
All four L2 dispenser migration generators read `olas.balanceOf(oldTargetDispenserL2Address)` and encode that into `updateWithheldAmountMaintenance()` on the replacement dispenser. Those are different quantities.

```solidity
// DefaultTargetDispenserL2.migrate()
uint256 amount = IToken(olas).balanceOf(address(this));
IToken(olas).transfer(newL2TargetDispenser, amount);
emit Migrated(msg.sender, newL2TargetDispenser, amount, withheldAmount);
```

`migrate()` moves the **full balance** and emits the stored `withheldAmount` **separately** — and never modifies it. The balance covers everything the dispenser held, including amounts that were never withheld; `withheldAmount` is specifically the portion L1 may re-use.

So encoding the balance overstates the reusable bucket on the new dispenser, and every later claim and refund draws on the wrong figure — silently, because nothing reconciles the two afterwards.

**Fix:** read `oldTargetDispenserL2.withheldAmount()` instead, in all four generators (mode, optimism, base, gnosis). Reading it at generation time is safe in either order, since `migrate()` leaves it untouched.

Also drops the OLAS token-contract wiring in each script — it existed only to make the `balanceOf` call and is now dead.

**No proposal generated from these scripts has been executed with the wrong value**, so this is a correction before the fact rather than a recovery.
