### PR TITLE
fix: bridge the Celo LP migration inputs to LPSwapCelo, not the bridge mediator

### DIFF
--- a/scripts/proposals/proposal_23_transfer_lp_token_celo.sh
+++ b/scripts/proposals/proposal_23_transfer_lp_token_celo.sh
@@ -37,8 +37,19 @@ celoL1StandardBridgeProxyAddress=$(jq -r '.celoL1StandardBridgeProxyAddress' $gl
 # Celo OLAS address (L2 token)
 celoOLASAddress=$(jq -r '.celoOLASAddress' $globalsStaking)
 
-# Bridge mediator on Celo (recipient of LP tokens)
+# Bridge mediator on Celo (recipient of the LPSwapCelo *outputs*, and migrate() target below)
 bridgeMediatorAddress=$(jq -r '.bridgeMediatorAddress' $globalsCelo)
+
+# LPSwapCelo on Celo — recipient of the bridged LP and the OLAS pre-funding.
+# swapLiquidity() reads both from its OWN balance (IToken(...).balanceOf(address(this))), so the
+# inputs must land on this contract. It then sends the re-added liquidity and any dust on to
+# BRIDGE_MEDIATOR itself. Bridging the inputs to the mediator instead would strand the migration
+# until governance forwarded them here in a second proposal.
+lpSwapCeloAddress=$(jq -r '.lpSwapCeloAddress' $globalsCelo)
+if [ -z "$lpSwapCeloAddress" ] || [ "$lpSwapCeloAddress" == "null" ]; then
+  echo "${red}lpSwapCeloAddress is not set in $globalsCelo — deploy LPSwapCelo first (scripts/deployment/utils/deploy_05_lp_swap_celo.sh)${reset}"
+  exit 1
+fi
 
 # Bridged LP token address
 lpTokenAddress="0xC085F31E4ca659fF8A17042dDB26f1dcA2fBdAB4"
@@ -57,6 +68,7 @@ echo "Wormhole Bridge:     $wormholeL1TokenRelayerAddress"
 echo "Celo Std Bridge:     $celoL1StandardBridgeProxyAddress"
 echo "Celo OLAS (L2):      $celoOLASAddress"
 echo "Bridge Mediator:     $bridgeMediatorAddress"
+echo "LPSwapCelo:          $lpSwapCeloAddress"
 echo "Wormhole Chain ID:   $celoWormholeL2TargetChainId"
 echo ""
 
@@ -70,8 +82,8 @@ if [ "$lpBalance" == "0" ]; then
   exit 1
 fi
 
-# Convert bridgeMediator address to bytes32 for Wormhole recipient
-recipientBytes32=$(cast --to-bytes32 $bridgeMediatorAddress)
+# Convert the LPSwapCelo address to bytes32 for the Wormhole recipient
+recipientBytes32=$(cast --to-bytes32 $lpSwapCeloAddress)
 
 # Step 1: Treasury.withdraw(timelockAddress, lpBalance, lpTokenAddress)
 echo ""
@@ -121,7 +133,7 @@ echo "Calldata: $calldata4a"
 echo ""
 echo "${green}Step 4b: depositERC20To() - bridge OLAS to Celo${reset}"
 minGasLimit=300000
-calldata4b=$(cast calldata "depositERC20To(address,address,address,uint256,uint32,bytes)" $olasAddress $celoOLASAddress $bridgeMediatorAddress $OLAS_AMOUNT $minGasLimit "0x")
+calldata4b=$(cast calldata "depositERC20To(address,address,address,uint256,uint32,bytes)" $olasAddress $celoOLASAddress $lpSwapCeloAddress $OLAS_AMOUNT $minGasLimit "0x")
 echo "Target:   $celoL1StandardBridgeProxyAddress"
 echo "Value:    0"
 echo "Calldata: $calldata4b"

--- a/scripts/proposals/proposal_23_transfer_lp_token_celo.sh
+++ b/scripts/proposals/proposal_23_transfer_lp_token_celo.sh
@@ -8,6 +8,7 @@ reset=$(tput sgr0)
 globalsMainnet="scripts/deployment/globals_mainnet.json"
 globalsStaking="scripts/deployment/staking/globals_mainnet.json"
 globalsCelo="scripts/deployment/staking/celo/globals_celo_mainnet.json"
+globalsCeloUtils="scripts/deployment/utils/globals_celo_mainnet.json"
 
 for f in $globalsMainnet $globalsStaking $globalsCelo; do
   if [ ! -f "$f" ]; then
@@ -45,9 +46,11 @@ bridgeMediatorAddress=$(jq -r '.bridgeMediatorAddress' $globalsCelo)
 # inputs must land on this contract. It then sends the re-added liquidity and any dust on to
 # BRIDGE_MEDIATOR itself. Bridging the inputs to the mediator instead would strand the migration
 # until governance forwarded them here in a second proposal.
-lpSwapCeloAddress=$(jq -r '.lpSwapCeloAddress' $globalsCelo)
+# Read from the utils globals, which is where deploy_05_lp_swap_celo.sh records the address
+# (it writes to "$(dirname "$0")/globals_<network>.json"); the staking globals above never gets it.
+lpSwapCeloAddress=$(jq -r '.lpSwapCeloAddress' $globalsCeloUtils)
 if [ -z "$lpSwapCeloAddress" ] || [ "$lpSwapCeloAddress" == "null" ]; then
-  echo "${red}lpSwapCeloAddress is not set in $globalsCelo — deploy LPSwapCelo first (scripts/deployment/utils/deploy_05_lp_swap_celo.sh)${reset}"
+  echo "${red}lpSwapCeloAddress is not set in $globalsCeloUtils — deploy LPSwapCelo first (scripts/deployment/utils/deploy_05_lp_swap_celo.sh celo_mainnet)${reset}"
   exit 1
 fi
 


### PR DESCRIPTION
Steps 2b and 4b bridge the LP token and the OLAS pre-funding to `bridgeMediatorAddress`. They need to go to `LPSwapCelo`, because that contract reads both from its **own** balance:

```solidity
uint256 liquidity = IToken(LP_TOKEN).balanceOf(address(this));
...
if (IToken(OLAS).balanceOf(address(this)) == 0) {
```

With the assets sitting at the mediator, `swapLiquidity()` has nothing to work with and the migration can't start. Recovering would take a second governance proposal just to forward both assets to the swap contract.

The mediator **is** the right destination for the swap's *outputs* — which `LPSwapCelo` already handles itself: `addLiquidity()` mints to `BRIDGE_MEDIATOR`, and leftover WCELO is transferred there. It just isn't the destination for the inputs.

**Fix:** point both bridge legs at `lpSwapCeloAddress`, read from the same Celo globals file that already supplies `bridgeMediatorAddress` and written there by `scripts/deployment/utils/deploy_05_lp_swap_celo.sh`. Added a guard so the script fails loudly if LPSwapCelo hasn't been deployed yet, rather than quietly encoding a `null` recipient into governance calldata.

**Unchanged, and correct as-is:** the `CrossDomainMessenger` target, and `migrate()` on the old `CeloTargetDispenserL2` — that OLAS is dispenser funds, not swap input, so the mediator is the right recipient there.

Caught before the proposal was executed, so nothing needs recovering.
