### PR TITLE
docs(audit): refresh the audit-candidates doc for #333

### DIFF
--- a/docs/external_audit_candidates.md
+++ b/docs/external_audit_candidates.md
@@ -29,17 +29,27 @@ externally-audited tag against the pre-external-audit snapshot of each repo:
 - **Tokenomics** — `v1.4.3-post-external-audit` → `v1.5.0-pre-external-audit`:
   https://github.com/valory-xyz/autonolas-tokenomics/compare/v1.4.3-post-external-audit...v1.5.0-pre-external-audit
   The `v1.5.0-pre-external-audit` tag is cut on `main`. The **contract changes** are the PRs listed below —
-  #306/#307/#309/#310/#311/#314/#315/#318/#319/#323/#326/#328 — plus the **comment-only** NatSpec scrub in
-  #325 (it touches `contracts/pol/*.sol` incl. `LiquidityManagerCore.sol` but changes no non-comment line:
+  #306/#307/#309/#310/#311/#314/#315/#318/#319/#323/#326/#328/#333 — plus the **comment-only** NatSpec scrub
+  in #325 (it touches `contracts/pol/*.sol` incl. `LiquidityManagerCore.sol` but changes no non-comment line:
   it only strips internal references such as `#306.1` / `VL#15` / `internal20 R6`). The full
-  `v1.4.3-post-external-audit…v1.5.0-pre-external-audit` range spans ~33 PRs (#287–#330); the remainder are
-  deployment, config, test, docs and audit-report changes, including the CI/doc follow-ups #329/#330.
+  `v1.4.3-post-external-audit…v1.5.0-pre-external-audit` range spans 40 merged PRs (#287–#338); the remainder
+  are deployment, config, test, docs and audit-report changes, including the CI/doc follow-ups #329/#330, the
+  vulnerabilities-list updates #334/#335/#336, and the Celo proposal-script correction #338 (a governance
+  proposal generator, no contract code).
 
   > **Tag maintenance (decision):** `v1.5.0-pre-external-audit` is **moved** (force-updated) to the `main` HEAD
   > that carries this doc correction — the tag name is stable, its target advances — so the snapshot the
   > auditors receive has the corrected references above, not the pre-fix `870d46f` state. This assumes the tag
   > has not yet been externally distributed; if it has, cut a suffixed tag (e.g. `-v2`, per the repo's
   > `v1.4.2-post-external-audit-v3` precedent) instead of re-pointing a published ref.
+  >
+  > **Applied again for this refresh.** Confirmed not yet externally distributed, so the tag is re-pointed
+  > rather than suffixed. Its previous target, `703e368`, was the last commit on #333's *branch*, so the tag
+  > already carried #333's contract fix and the merge commit adds no content — moving it onto `main`'s
+  > first-parent line is what changes. Between `703e368` and the new target only
+  > `docs/Vulnerabilities_list_tokenomics.md` and one governance proposal script differ: **no `contracts/`
+  > file changes**, so the audited contract set is byte-identical either way and the move only buys the
+  > auditors a current known-issues list.
 
 - **Governance** — last external-audit tag → `v1.3.0-pre-external-audit`:
   https://github.com/valory-xyz/autonolas-governance/compare/<last-audited-tag>...v1.3.0-pre-external-audit
@@ -73,7 +83,7 @@ The following needs to be audited:
 
 1. Dispenser.sol — 717 SLoC — delta: +211 / −90 (~301 lines changed)
 2. DispenserProxy.sol — 34 SLoC — new file (entire file new)
-3. LiquidityManagerCore.sol — 673 SLoC — delta: +244 / −95 (~335 lines changed; price-guard fail-closed, the deviation-gate tightening, and the source-side ratio cross-check that replaces the removeLiquidity TWAP oracle)
+3. LiquidityManagerCore.sol — 677 SLoC — delta: +279 / −95 (~374 lines changed; price-guard fail-closed, the deviation-gate tightening, the source-side ratio cross-check that replaces the removeLiquidity TWAP oracle, and the `collectFees` token-ordering alignment from #333)
 
 LiquidityManager refactor — the former `LiquidityManagerETH` / `LiquidityManagerOptimism` are removed and
 their bodies decomposed into composable source / target / burn mixins over `LiquidityManagerCore`, plus one
@@ -96,9 +106,9 @@ logic; its one remaining `WrongTokenAddresses` error moved into `LiquidityManage
 mixins now extend `LiquidityManagerCore` directly.)
 
 **Contracts Number: 12**
-**Total SLoC (full files): 1749** — Dispenser 717, DispenserProxy 34, LiquidityManagerCore 673, and the
+**Total SLoC (full files): 1753** — Dispenser 717, DispenserProxy 34, LiquidityManagerCore 677, and the
 LiquidityManager refactor 325 (mixins 230 + leaves 95). Changed-lines scope: ~301 in Dispenser, 34 new in
-DispenserProxy, ~335 in LiquidityManagerCore, and the 325-SLoC refactor (mostly extraction; ~95 SLoC of
+DispenserProxy, ~374 in LiquidityManagerCore, and the 325-SLoC refactor (mostly extraction; ~95 SLoC of
 genuinely new leaf/composition code across the four leaves).
 
 ### Scope of changes for Dispenser / DispenserProxy


### PR DESCRIPTION
Prepares `docs/external_audit_candidates.md` for the `v1.5.0-pre-external-audit` tag move, and fixes a scoping omission while doing it.

### #333 was missing from the contract-change list

The list read `#306/#307/#309/#310/#311/#314/#315/#318/#319/#323/#326/#328`. **#333** changed `contracts/pol/LiquidityManagerCore.sol` (+11/−0, the `collectFees` token-ordering alignment) and wasn't there. An auditor scoping from that list would not have known `collectFees` changed.

I checked the whole range rather than assuming: `a6c7dd1` (#333) is the **only** commit touching `contracts/` since the doc was written, so it's the only addition needed.

### The per-contract figures were already wrong

Measured against `v1.4.3-post-external-audit`:

| | doc | actual |
|---|---|---|
| delta | +244 / −95 | **+279 / −95** |
| SLoC | 673 | **677** |
| total | 1749 | **1753** |

Worth flagging that the delta was understated *before* #333 too — it was already `+268 / −95` at the time the doc was written, so 24 added lines were missing independently.

The SLoC figure cross-checks two ways: #333's 11 added lines are 4 code + 6 comment + 1 blank, so `673 + 4 = 677`, and an independent code-line count of the file at HEAD also gives 677.

### Range and tag note

`~33 PRs (#287–#330)` → `40 merged PRs (#287–#338)`, with the newer ones named so the count reconciles: #334/#335/#336 are vulnerabilities-list updates, #338 is a governance proposal-script correction — none of them contract code.

The tag-maintenance block now records that the decision is being applied a second time, with the specifics that make it safe:

- distribution confirmed **not** to have happened, so re-pointing rather than suffixing is the sanctioned path;
- the previous target `703e368` was the last commit on **#333's own branch**, so the tag already carried that contract fix and the merge commit adds no content — what changes is that the tag lands on `main`'s first-parent line;
- between `703e368` and the new target, **no `contracts/` file differs at all** — only the vulnerabilities list and one proposal script — so the audited contract set is byte-identical either way and the move only buys the auditors a current known-issues list.

Once this merges, the tag should be re-pointed at the resulting `main` HEAD (not at the #333 merge commit), so the snapshot carries these corrections — which is the same rationale the original decision used.
