### PR TITLE
docs(audit): complete the governance scope and fix its tag reference

### DIFF
--- a/docs/external_audit_candidates.md
+++ b/docs/external_audit_candidates.md
@@ -51,9 +51,19 @@ externally-audited tag against the pre-external-audit snapshot of each repo:
   > file changes**, so the audited contract set is byte-identical either way and the move only buys the
   > auditors a current known-issues list.
 
-- **Governance** — last external-audit tag → `v1.3.0-pre-external-audit`:
-  https://github.com/valory-xyz/autonolas-governance/compare/<last-audited-tag>...v1.3.0-pre-external-audit
-  (per-contract diff is PR https://github.com/valory-xyz/autonolas-governance/pull/215).
+- **Governance** — `v1.2.5-post-external-audit` → `v1.3.0-pre-external-audit`:
+  https://github.com/valory-xyz/autonolas-governance/compare/v1.2.5-post-external-audit...v1.3.0-pre-external-audit
+  (the `VoteWeighting` per-contract diff is PR https://github.com/valory-xyz/autonolas-governance/pull/215).
+  Across that range only two **production** contracts differ — `VoteWeighting.sol` and `GuardCM.sol`; the
+  other changed files under `contracts/` are test harnesses (`test/EchidnaVoteWeightingAssert.sol`,
+  `test/MockDispenser.sol`, `test/VoteWeightingFuzzing.sol`) and are not audit scope.
+
+  > **Tag maintenance (decision):** the same policy as for tokenomics above applies to
+  > `v1.3.0-pre-external-audit`, and it is **moved** to the `main` HEAD carrying this correction.
+  > Confirmed not yet externally distributed. Between the tag's previous target (`1159e5d`) and that HEAD
+  > the only file that differs is `docs/Vulnerabilities_list_governance.md` (+48/−0, known-issues items
+  > added by #219 and corrected by #220) — **no `contracts/` file changes** — so the audited contract set
+  > is byte-identical and the move only gives the auditors the current known-issues list.
 
 Per-contract line deltas below are the raw `git diff` (added / removed) against
 `v1.4.3-post-external-audit`; the SLoC figures are `cloc` code lines on the merged file.
@@ -63,9 +73,20 @@ Per-contract line deltas below are the raw `git diff` (added / removed) against
 The following needs to be audited:
 
 1. VoteWeighting.sol — 437 SLoC — delta: +63 / −39 (~102 lines changed)
+2. GuardCM.sol — 253 SLoC — delta: +1 / −2 (3 lines changed; `setBridgeMediatorL1BridgeParams` now also
+   rejects a zero `bridgeMediatorL2s[i]`, and the note stating that an L2 mediator may legitimately be zero
+   "for example, for Arbitrum case" is removed)
 
-**Contracts Number: 1**
-**Total SLoC (full file): 437 — Changed lines: ~102**
+**Contracts Number: 2**
+**Total SLoC (full files): 690** — VoteWeighting 437, GuardCM 253. **Changed lines: ~105** — ~102 in
+VoteWeighting, 3 in GuardCM.
+
+> `GuardCM.sol` was previously omitted from this scope. Its delta is one line of logic, but it is a
+> behavioural tightening rather than a comment change, so it belongs in the listed set. Reviewers should
+> note the interaction it creates: the removed comment asserted that a zero L2 bridge mediator is valid for
+> some chains, Arbitrum being the named example, and the new check rejects exactly that — so whether every
+> supported chain still configures cleanly through `setBridgeMediatorL1BridgeParams` is worth confirming
+> against the live per-chain parameters rather than assumed.
 
 ### Scope of changes for VoteWeighting
 


### PR DESCRIPTION
Checking whether the other repos needed the same treatment as tokenomics turned up three problems in the **governance** half of this doc. (Registries and marketplace tags are from earlier rounds — registries even has a newer `post-external-audit` — and staking-programmes has no audit tags, so governance is the only other repo in this round.)

### 1. The compare link was a literal placeholder

```
compare/<last-audited-tag>...v1.3.0-pre-external-audit
```

The tag exists — `v1.2.5-post-external-audit` — so the link now resolves.

### 2. `GuardCM.sol` was missing from the scope

The doc claimed **"Contracts Number: 1"**. Across `v1.2.5-post-external-audit → v1.3.0-pre-external-audit`, **two** production contracts differ:

| Contract | SLoC | delta |
|---|---|---|
| VoteWeighting.sol | 437 | +63 / −39 *(already listed, and correct)* |
| **GuardCM.sol** | **253** | **+1 / −2** *(was missing)* |

It's already inside the audited snapshot — it landed 2026-03-04 — and it's behavioural, not a comment edit:

```diff
-            // Note that bridgeMediatorL2-s can be zero addresses, for example, for Arbitrum case
-            if (bridgeMediatorL1s[i] == address(0) || verifierL2s[i] == address(0)) {
+            if (bridgeMediatorL1s[i] == address(0) || verifierL2s[i] == address(0) || bridgeMediatorL2s[i] == address(0)) {
```

Totals become 2 contracts / 690 SLoC / ~105 changed lines. The other changed files under `contracts/` are test harnesses (`EchidnaVoteWeightingAssert`, `MockDispenser`, `VoteWeightingFuzzing`) and are now named as out of scope, so the count reconciles instead of looking arbitrary.

**One thing for reviewers, not asserted as a finding:** the comment that change removed said a zero L2 mediator is valid for some chains, *naming Arbitrum* — and the new check rejects exactly that. Whether every supported chain still configures cleanly through `setBridgeMediatorL1BridgeParams` is worth confirming against the live per-chain parameters rather than assumed.

### 3. No tag-maintenance record for the governance tag

Now recorded on the same terms as tokenomics: not yet externally distributed, and between the tag's previous target `1159e5d` and `main` HEAD the only file that differs is `docs/Vulnerabilities_list_governance.md` (+48/−0, from #219 and #220) — **no `contracts/` changes** — so the audited contract set is byte-identical and moving it only gives auditors the current known-issues list.

---

SLoC uses the same counting as the existing entries: I reproduced VoteWeighting's published **437** exactly before measuring GuardCM, so the new figure is consistent with the rest of the table rather than from a different tool.

Once this merges, both tags get pointed at their respective `main` HEADs — governance for the first time, tokenomics re-pointed so it carries this correction.
