### PR TITLE
chore(config): drop the three unused LiquidityManagerProxy entries

### DIFF
--- a/docs/configuration.json
+++ b/docs/configuration.json
@@ -106,11 +106,6 @@
         "name": "LiquidityManagerUniV2UniV3",
         "artifact": "abis/deployed/LiquidityManagerUniV2UniV3.json",
         "address": "0x0171D7178fbf3B48E75675DEE2EA3EfecEf775C1"
-      },
-      {
-        "name": "LiquidityManagerProxy",
-        "artifact": "abis/0.8.30/LiquidityManagerProxy.json",
-        "address": "0x83Adc54B2828E99a6DA3A11263C75E38E0A1a215"
       }
     ]
   },
@@ -245,11 +240,6 @@
         "name": "LiquidityManagerBalancerSlipstream",
         "artifact": "abis/deployed/LiquidityManagerBalancerSlipstream.json",
         "address": "0xCf9B4710fe450Dca52374f28e4917FDCd44F9487"
-      },
-      {
-        "name": "LiquidityManagerProxy",
-        "artifact": "abis/0.8.30/LiquidityManagerProxy.json",
-        "address": "0x1f84F8F70dE0651C2d51Bf8850FE9D0289Ba3B3A"
       }
     ]
   },
@@ -291,11 +281,6 @@
         "name": "LiquidityManagerBalancerSlipstream",
         "artifact": "abis/deployed/LiquidityManagerBalancerSlipstream.json",
         "address": "0x1D64516E7654F23dB7cE2ddaD00FFb3E765cf5ce"
-      },
-      {
-        "name": "LiquidityManagerProxy",
-        "artifact": "abis/0.8.30/LiquidityManagerProxy.json",
-        "address": "0x2ACD313B892C9922E470e4950e907d5EAa70fC2a"
       }
     ]
   },


### PR DESCRIPTION
The mainnet, optimism and base `LiquidityManagerProxy` deployments **appear never to have been used**.

All three were deployed on **2026-05-18** and since then have emitted **no events** and hold **no native balance and no OLAS**:

| chain | address | deployed | events | native | OLAS |
|---|---|---|---|---|---|
| mainnet | `0x83Adc54B2828E99a6DA3A11263C75E38E0A1a215` | block 25,121,761 | 0 | 0 | 0 |
| optimism | `0x1f84F8F70dE0651C2d51Bf8850FE9D0289Ba3B3A` | block 151,753,148 | 0 | 0 | 0 |
| base | `0x2ACD313B892C9922E470e4950e907d5EAa70fC2a` | block 46,157,692 | 0 | 0 | 0 |

*(A few log-query ranges failed against public endpoints, so treat zero events as very strong rather than absolute.)*

With a replacement POL stack queued for deployment, carrying them here costs more than it gives: the auditor checks three contracts nobody uses, and they show up in ownership sweeps as deployer-held, which reads as a migration task when the right action is to retire them.

`docs/configuration.json` is the **audit target list**, not a deployment history — and it was never capable of being one, since anyone can deploy these contracts and we would not know. What belongs here is what the protocol relies on and therefore wants checked.

The implementations they point at — `LiquidityManagerUniV2UniV3` and `LiquidityManagerBalancerSlipstream` — **stay** in the configuration and remain checked.
