### PR TITLE
docs: record the one-sided target pair check for the Celo LP swap

### DIFF
--- a/docs/liquidity_migration_runbook.md
+++ b/docs/liquidity_migration_runbook.md
@@ -204,6 +204,26 @@ no one can race the `initialize()` and set a wrong price. On ETH do it in a priv
 create/init/pre-seed is done by a native-L2 actor during prep, where OP-stack's absence of a public
 mempool already makes it effectively private.
 
+### 3.4 Celo OLAS/WCELO — one-sided target pair blocks the swap
+
+Same family as §3.3, on the Celo V2-style swap (`LPSwapCelo`) rather than a V3 pool. The target pair is
+created lazily, and anyone may create and seed it first.
+
+`LPSwapCelo` already guards a pre-existing pair whose reserves are **skewed**, by deriving minimum amounts
+from the TWAP-protected removal. It does not cover a pair seeded on **one side only**: the router branches
+on reserves, and a `(X, 0)` pair is neither the both-zero case nor quotable, so `UniswapV2Library.quote`
+reverts `INSUFFICIENT_LIQUIDITY` **before** the minimums are consulted. The guard is bypassed rather than
+triggered, which is why the revert reads as unrelated to slippage.
+
+**No funds are at risk** — the transaction is atomic, so the source LP removal rolls back. But the pair
+keeps its state, so retries fail identically until it is repaired.
+
+- **Before submitting, and again on any revert:** read the target pair's reserves.
+- **If exactly one reserve is zero:** send dust of the missing token to the pair, call `sync()`, retry.
+  Both steps are permissionless — no privileged key and no governance action needed.
+
+---
+
 ---
 
 ## 4. Source oracle warm-up — no longer applicable

--- a/scripts/proposals/proposal_23_transfer_lp_token_celo.sh
+++ b/scripts/proposals/proposal_23_transfer_lp_token_celo.sh
@@ -1,4 +1,24 @@
 #!/bin/bash
+#
+# Celo OLAS/CELO LP transfer and swap.
+#
+# PRE-FLIGHT — read the target pair's reserves before submitting, and again if this reverts.
+#
+# The target OLAS/WCELO pair is created lazily and anyone may create and seed it first. LPSwapCelo guards a
+# pre-existing pair whose reserves are *skewed*, by deriving minimum amounts from the TWAP-protected
+# removal — but a pair seeded on ONE SIDE ONLY is neither empty nor quotable, so the router reverts inside
+# UniswapV2Library.quote ("INSUFFICIENT_LIQUIDITY") before those minimums are ever consulted. The guard is
+# bypassed rather than triggered, which is why the revert looks unrelated to slippage.
+#
+# Nothing is lost when this happens: the transaction is atomic, so the source LP removal rolls back. But the
+# pair keeps its state, so every retry fails identically until it is repaired.
+#
+#   Check:  cast call <OLAS/WCELO pair> "getReserves()(uint112,uint112,uint32)" --rpc-url <celo>
+#   Repair: if exactly one reserve is zero, send dust of the missing token to the pair, call sync(), retry.
+#           Both are permissionless, so this needs no privileged key.
+#
+# See docs/Vulnerabilities_list_tokenomics.md entry 37.
+#
 
 red=$(tput setaf 1)
 green=$(tput setaf 2)


### PR DESCRIPTION
Operational follow-up to vulnerabilities list entry 37.

`LPSwapCelo` already guards a pre-existing target pair whose reserves are **skewed**, by deriving minimum amounts from the TWAP-protected removal. It does not cover a pair seeded on **one side only**: the router branches on reserves, and a `(X, 0)` pair is neither the both-zero case nor quotable, so `UniswapV2Library.quote` reverts `INSUFFICIENT_LIQUIDITY` **before** the minimums are consulted.

The guard is bypassed rather than triggered — which is why the revert reads as unrelated to slippage, and why this is worth writing down rather than leaving to be diagnosed live. Creating and seeding the pair is permissionless.

**Nothing is at risk when it happens.** The transaction is atomic, so the source LP removal rolls back. But the pair keeps its state, so retries fail identically until it is repaired — and the repair is permissionless too, so it needs no privileged key or governance action.

## Recorded in the two places an operator would look

- **A pre-flight block on `proposal_23_transfer_lp_token_celo.sh`**, which is the script actually run — with the `cast call` to read the reserves and the dust-plus-`sync()` repair.
- **Runbook §3.4**, alongside §3.3's V3 `initialize()` front-run, which is the same family of problem on the V3 side.

No code change.