### PR TITLE
docs: state that fee-on-transfer and rebasing tokens are unsupported

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ The Depository and Treasury contracts are inspired by OlympusDAO concepts. The T
 for component and agent owners, the logic that regulates the discount factor for bonds, and Olas staking emissions.
 The Tokenomics contract is deployed via the proxy contract, such that it is possible to update the current Tokenomics implementation.
 
+Note that by default the contracts do not work with:
+- Fee on transfer tokens;
+- Balance changes outside token transfers.
+
+This applies in particular to the Treasury reserve ledger, which tracks protocol-owned liquidity: bond
+deposits are booked at their nominal amount on the assumption that governance enables only LP tokens with
+standard `UniswapV2ERC20` transfer semantics.
+
 - Core contracts:
   - [Depository](contracts/Depository.sol)
   - [Dispenser](contracts/Dispenser.sol)


### PR DESCRIPTION
`autonolas-registries` states this in its README; `autonolas-tokenomics` does not, so the assumption lives only in `Treasury` source comments:

> `// We assume that authorized LP tokens in the protocol are safe as they are enabled via the governance`
> `// UniswapV2ERC20 realization has a standard transferFrom() function that returns a boolean value`

— above the deposit transfer, and again above the withdrawal.

## Why it is worth stating in the README

The boundary is load-bearing. The Treasury reserve ledger books bond deposits at their **nominal** amount and reconciles against nothing, which is correct for standard LP tokens and wrong for any token whose balance moves outside a transfer. Someone reading only the README could reasonably conclude the ledger is meant to hold arbitrary tokens — and then report the resulting divergence as a defect.

That has now happened, so this is a real gap rather than a hypothetical one.

## What it says

The two lines are copied verbatim from the registries README so both repos state the same assumption in the same terms, plus one sentence naming where it bites:

> Note that by default the contracts do not work with:
> - Fee on transfer tokens;
> - Balance changes outside token transfers.
>
> This applies in particular to the Treasury reserve ledger, which tracks protocol-owned liquidity: bond deposits are booked at their nominal amount on the assumption that governance enables only LP tokens with standard `UniswapV2ERC20` transfer semantics.

Documentation only — no code change.