### PR TITLE
docs: state the staked-service top-up rule in source, and correct entry 41

### DIFF
--- a/contracts/Tokenomics.sol
+++ b/contracts/Tokenomics.sol
@@ -916,6 +916,14 @@ contract Tokenomics is TokenomicsConstants {
             // functions to check each service owner veOLAS balance
             bool topUpEligible;
             if (incentiveFlags[2] || incentiveFlags[3]) {
+                // NOTE: for a STAKED service this reads the staking contract, not the person who staked it.
+                // Staking transfers the service NFT to the staking instance, while StakingBase keeps the
+                // original caller in its own ServiceInfo.owner, so the two notions of "owner" diverge and
+                // ownerOf() returns an address that holds no veOLAS. The owner leg of the check below
+                // therefore cannot qualify a staked service. That is intended, not an oversight: a staked
+                // service is already earning staking rewards, and an owner-qualified top-up would be a
+                // second reward stream for the same service. Only the owner leg is affected — a donator
+                // above the threshold still qualifies the donation, since the condition is an OR.
                 address serviceOwner = IToken(serviceRegistry).ownerOf(serviceIds[i]);
                 topUpEligible = (IVotingEscrow(ve).getVotes(serviceOwner) >= veOLASThreshold  ||
                     IVotingEscrow(ve).getVotes(donator) >= veOLASThreshold) ? true : false;

--- a/docs/Vulnerabilities_list_tokenomics.md
+++ b/docs/Vulnerabilities_list_tokenomics.md
@@ -1042,14 +1042,25 @@ address serviceOwner = IToken(serviceRegistry).ownerOf(serviceIds[i]);
 
 Staking a deployed service transfers that NFT to the staking contract, while `StakingBase` keeps the
 original caller in `ServiceInfo.owner`. For any staked service the two therefore disagree, and `ownerOf`
-returns the staking instance rather than the person who staked it — so a donation to a staked service never
-qualifies its owner for the top-up.
+returns the staking instance rather than the person who staked it. That address holds no veOLAS, so the
+**owner** leg of the eligibility test can never pass for a staked service.
+
+**Only the owner leg is affected.** The test is an `OR`:
+
+```solidity
+topUpEligible = (IVotingEscrow(ve).getVotes(serviceOwner) >= veOLASThreshold ||
+    IVotingEscrow(ve).getVotes(donator) >= veOLASThreshold) ? true : false;
+```
+
+so a donator whose own veOLAS is above the threshold still qualifies the donation. What is lost is the
+ability of the *service owner's* stake to qualify it.
 
 **This is the intended economics, not a loss.** A staked service is already earning staking rewards, and an
 owner-qualified top-up would be a second reward stream for the same service. The entry exists because the
 rule is enforced only as a side effect of NFT custody and is stated nowhere: a reader comparing
 `Tokenomics` against `StakingBase` sees two different notions of "owner" and no explanation. Integrators
-modelling expected returns for a staked service should not expect donation top-ups.
+should not rely on a staked service's *owner* stake to qualify donations to it — but a qualifying donator
+still works.
 
 ### 42. Retainer skip is chain-bound while the claim guards are not
 


### PR DESCRIPTION
Two changes, both in this repo.

## The rule, written down

`Tokenomics._trackServiceDonations()` reads `ownerOf(serviceId)` to decide top-up eligibility. For a **staked** service that returns the staking instance, not the person who staked it — `StakingBase` keeps the original caller in its own `ServiceInfo.owner`, so the two notions of "owner" diverge — and the staking instance holds no veOLAS. The owner leg therefore can never qualify a staked service.

**That is intended:** a staked service is already earning staking rewards, and an owner-qualified top-up would be a second reward stream for the same service.

The problem was that this was enforced only as a *side effect of NFT custody* and stated nowhere, so a reader comparing the two contracts saw two different notions of owner and no explanation. The comment says so at the point of the read.

**Contract change is comment-only** — 8 added lines, all `//`, nothing removed.

## Correcting entry 41

Entry 41 was added yesterday and **overstates the consequence**. It said integrators "should not expect donation top-ups" for a staked service. That is too strong. The eligibility test is an `OR`:

```solidity
topUpEligible = (IVotingEscrow(ve).getVotes(serviceOwner) >= veOLASThreshold ||
    IVotingEscrow(ve).getVotes(donator) >= veOLASThreshold) ? true : false;
```

so a **donator** whose own veOLAS is above the threshold still qualifies the donation. Only the *owner* leg is neutralised. The entry now shows the condition and says which half is affected, rather than implying top-ups are unavailable entirely.

I noticed this while writing the source comment — getting the comment right required reading the condition properly, which the entry had not.