### PR TITLE
feat(staking): Robinhood Chain (4663) globals, and restore the missing dispenserProxyAddress

### DIFF
--- a/scripts/deployment/staking/_preflight_dispenser.sh
+++ b/scripts/deployment/staking/_preflight_dispenser.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Shared preflight for every script that binds or registers against the L1 Dispenser.
+#
+# WHY THIS EXISTS. DefaultDepositProcessorL1.l1Dispenser is `immutable`, so a processor deployed against the
+# wrong Dispenser can never be repaired — claims from the live one revert ManagerOnly. The trap is that
+# deploy_07b_dispenser_proxy.sh writes `dispenserProxyAddress` into scripts/deployment/globals_<network>.json,
+# a DIFFERENT file from the staking globals these scripts read, so a Dispenser proxy migration silently leaves
+# the value here pointing at the retired contract.
+#
+# Expects in scope: $globals, $dispenserProxyAddress, $1 (network suffix), and the red/green/reset vars.
+# Source it immediately after reading dispenserProxyAddress and before building any constructor args.
+
+zeroAddress="0x0000000000000000000000000000000000000000"
+if [ -z "$dispenserProxyAddress" ] || [ "$dispenserProxyAddress" == "null" ] \
+   || [ "$dispenserProxyAddress" == "$zeroAddress" ]; then
+  echo "${red}!!! dispenserProxyAddress is not set (or zero) in $globals${reset}"
+  exit 1
+fi
+
+deploymentGlobals="$(dirname "$0")/../globals_${1}.json"
+if [ ! -f "$deploymentGlobals" ]; then
+  # Warn rather than fail: not every network has a deployment-side globals file, and failing here would
+  # regress runs that work today. Silence would be the wrong shape for a guard against an unrecoverable
+  # binding, so it is loud.
+  echo "${red}!!! WARNING: cannot cross-check the Dispenser binding — $deploymentGlobals not found.${reset}"
+  echo "${red}!!!          l1Dispenser is immutable. Confirm $dispenserProxyAddress is the live Dispenser${reset}"
+  echo "${red}!!!          before continuing.${reset}"
+else
+  liveDispenser=$(jq -r '.dispenserProxyAddress // .dispenserAddress // empty' "$deploymentGlobals")
+  if [ -z "$liveDispenser" ]; then
+    echo "${red}!!! $deploymentGlobals has neither dispenserProxyAddress nor dispenserAddress${reset}"
+    exit 1
+  fi
+  if [ "$(echo "$liveDispenser" | tr '[:upper:]' '[:lower:]')" \
+     != "$(echo "$dispenserProxyAddress" | tr '[:upper:]' '[:lower:]')" ]; then
+    echo "${red}!!! Dispenser binding mismatch — refusing to bind to a stale address${reset}"
+    echo "${red}    $globals            dispenserProxyAddress = $dispenserProxyAddress${reset}"
+    echo "${red}    $deploymentGlobals  says the live Dispenser is $liveDispenser${reset}"
+    echo "${red}    Reconcile the two before deploying; l1Dispenser cannot be changed afterwards.${reset}"
+    exit 1
+  fi
+  echo "${green}Dispenser binding cross-checked against $deploymentGlobals${reset}"
+fi

--- a/scripts/deployment/staking/arbitrum/globals_robinhood_mainnet.json
+++ b/scripts/deployment/staking/arbitrum/globals_robinhood_mainnet.json
@@ -1,0 +1,17 @@
+{
+  "contractVerification": true,
+  "useLedger": true,
+  "derivationPath": "m/44'/60'/2'/0/0",
+  "providerName": "robinhood",
+  "chainId": "4663",
+  "networkURL": "https://rpc.mainnet.chain.robinhood.com",
+  "blockscoutURL": "https://robinhoodchain.blockscout.com",
+  "gasPriceInGwei": "1",
+  "olasAddress": "0x092963938DEBd8013a2E545B3549f8a5EC0d2286",
+  "serviceStakingFactoryAddress": "",
+  "bridgeMediatorAddress": "0x4d30F68F5AA342d296d4deE4bB1Cacca912dA70F",
+  "arbitrumArbSysAddress": "0x0000000000000000000000000000000000000064",
+  "l1ChainId": "1",
+  "arbitrumDepositProcessorL1Address": "",
+  "arbitrumTargetDispenserL2Address": ""
+}

--- a/scripts/deployment/staking/deploy_02_arbitrum_deposit_processor.sh
+++ b/scripts/deployment/staking/deploy_02_arbitrum_deposit_processor.sh
@@ -27,6 +27,9 @@ networkURL=$(jq -r '.networkURL' $globals)
 
 olasAddress=$(jq -r '.olasAddress' $globals)
 dispenserProxyAddress=$(jq -r '.dispenserProxyAddress' $globals)
+
+# Preflight: cross-check the Dispenser binding (see _preflight_dispenser.sh).
+. "$(dirname "$0")/_preflight_dispenser.sh"
 arbitrumL1ERC20GatewayRouterAddress=$(jq -r '.arbitrumL1ERC20GatewayRouterAddress' $globals)
 arbitrumInboxAddress=$(jq -r '.arbitrumInboxAddress' $globals)
 arbitrumL2TargetChainId=$(jq -r '.arbitrumL2TargetChainId' $globals)

--- a/scripts/deployment/staking/deploy_03_gnosis_deposit_processor.sh
+++ b/scripts/deployment/staking/deploy_03_gnosis_deposit_processor.sh
@@ -27,6 +27,9 @@ networkURL=$(jq -r '.networkURL' $globals)
 
 olasAddress=$(jq -r '.olasAddress' $globals)
 dispenserProxyAddress=$(jq -r '.dispenserProxyAddress' $globals)
+
+# Preflight: cross-check the Dispenser binding (see _preflight_dispenser.sh).
+. "$(dirname "$0")/_preflight_dispenser.sh"
 gnosisOmniBridgeAddress=$(jq -r '.gnosisOmniBridgeAddress' $globals)
 gnosisAMBForeignAddress=$(jq -r '.gnosisAMBForeignAddress' $globals)
 gnosisL2TargetChainId=$(jq -r '.gnosisL2TargetChainId' $globals)

--- a/scripts/deployment/staking/deploy_04_optimism_deposit_processor.sh
+++ b/scripts/deployment/staking/deploy_04_optimism_deposit_processor.sh
@@ -27,6 +27,9 @@ networkURL=$(jq -r '.networkURL' $globals)
 
 olasAddress=$(jq -r '.olasAddress' $globals)
 dispenserProxyAddress=$(jq -r '.dispenserProxyAddress' $globals)
+
+# Preflight: cross-check the Dispenser binding (see _preflight_dispenser.sh).
+. "$(dirname "$0")/_preflight_dispenser.sh"
 optimismL1StandardBridgeProxyAddress=$(jq -r '.optimismL1StandardBridgeProxyAddress' $globals)
 optimismL1CrossDomainMessengerProxyAddress=$(jq -r '.optimismL1CrossDomainMessengerProxyAddress' $globals)
 optimismL2TargetChainId=$(jq -r '.optimismL2TargetChainId' $globals)

--- a/scripts/deployment/staking/deploy_05_celo_deposit_processor.sh
+++ b/scripts/deployment/staking/deploy_05_celo_deposit_processor.sh
@@ -27,6 +27,9 @@ networkURL=$(jq -r '.networkURL' $globals)
 
 olasAddress=$(jq -r '.olasAddress' $globals)
 dispenserProxyAddress=$(jq -r '.dispenserProxyAddress' $globals)
+
+# Preflight: cross-check the Dispenser binding (see _preflight_dispenser.sh).
+. "$(dirname "$0")/_preflight_dispenser.sh"
 celoL1StandardBridgeProxyAddress=$(jq -r '.celoL1StandardBridgeProxyAddress' $globals)
 celoL1CrossDomainMessengerProxyAddress=$(jq -r '.celoL1CrossDomainMessengerProxyAddress' $globals)
 celoL2TargetChainId=$(jq -r '.celoL2TargetChainId' $globals)

--- a/scripts/deployment/staking/deploy_06_polygon_deposit_processor.sh
+++ b/scripts/deployment/staking/deploy_06_polygon_deposit_processor.sh
@@ -27,6 +27,9 @@ networkURL=$(jq -r '.networkURL' $globals)
 
 olasAddress=$(jq -r '.olasAddress' $globals)
 dispenserProxyAddress=$(jq -r '.dispenserProxyAddress' $globals)
+
+# Preflight: cross-check the Dispenser binding (see _preflight_dispenser.sh).
+. "$(dirname "$0")/_preflight_dispenser.sh"
 polygonRootChainManagerProxyAddress=$(jq -r '.polygonRootChainManagerProxyAddress' $globals)
 polygonFXRootAddress=$(jq -r '.polygonFXRootAddress' $globals)
 polygonL2TargetChainId=$(jq -r '.polygonL2TargetChainId' $globals)

--- a/scripts/deployment/staking/deploy_07_base_deposit_processor.sh
+++ b/scripts/deployment/staking/deploy_07_base_deposit_processor.sh
@@ -27,6 +27,9 @@ networkURL=$(jq -r '.networkURL' $globals)
 
 olasAddress=$(jq -r '.olasAddress' $globals)
 dispenserProxyAddress=$(jq -r '.dispenserProxyAddress' $globals)
+
+# Preflight: cross-check the Dispenser binding (see _preflight_dispenser.sh).
+. "$(dirname "$0")/_preflight_dispenser.sh"
 baseL1StandardBridgeProxyAddress=$(jq -r '.baseL1StandardBridgeProxyAddress' $globals)
 baseL1CrossDomainMessengerProxyAddress=$(jq -r '.baseL1CrossDomainMessengerProxyAddress' $globals)
 baseL2TargetChainId=$(jq -r '.baseL2TargetChainId' $globals)

--- a/scripts/deployment/staking/deploy_08_eth_deposit_processor.sh
+++ b/scripts/deployment/staking/deploy_08_eth_deposit_processor.sh
@@ -20,6 +20,9 @@ networkURL=$(jq -r '.networkURL' $globals)
 
 olasAddress=$(jq -r '.olasAddress' $globals)
 dispenserProxyAddress=$(jq -r '.dispenserProxyAddress' $globals)
+
+# Preflight: cross-check the Dispenser binding (see _preflight_dispenser.sh).
+. "$(dirname "$0")/_preflight_dispenser.sh"
 serviceStakingFactoryAddress=$(jq -r '.serviceStakingFactoryAddress' $globals)
 timelockAddress=$(jq -r '.timelockAddress' $globals)
 

--- a/scripts/deployment/staking/deploy_10_set_deposit_processors.js
+++ b/scripts/deployment/staking/deploy_10_set_deposit_processors.js
@@ -9,6 +9,23 @@
  * the claim, and in the batch path it takes the other chains' claims down with it.
  *
  * `deploy_10_set_deposit_processors.sh` is the equivalent shell route and is the preferred one.
+ *
+ * TWO CONSEQUENCES OF THE HARD FAIL, both deliberate:
+ *
+ *   1. This script is inoperative on `main` until wave 1 deploys. `robinhoodDepositProcessorL1Address`
+ *      ships empty, so until Robinhood Chain is live the script throws for EVERY chain, not just
+ *      Robinhood. That is the ordering rule above doing its job, but it means someone reaching for
+ *      this during an unrelated incident hits a wall that has nothing to do with their chain.
+ *
+ *   2. It cannot express "disable a route". `Dispenser.setDepositProcessorChainIds` treats a zero
+ *      processor as meaningful — "might be zero if there is a need to stop processing a specific L2
+ *      chain Id" — and `requireAddress` rejects zero. Disabling a chain is a targeted call with a
+ *      one-element array, not this bulk-register tool.
+ *
+ * NOTE ON PERMISSIONS: `Dispenser.owner()` is the Timelock, so on mainnet this call cannot be sent
+ * from the deploying EOA at all — it reverts OwnerOnly and belongs in a governance proposal. Both
+ * routes are therefore fresh-deployment tooling and a calldata reference, not an operational path
+ * against the live Dispenser.
  */
 
 const { ethers } = require("hardhat");

--- a/scripts/deployment/staking/deploy_10_set_deposit_processors.js
+++ b/scripts/deployment/staking/deploy_10_set_deposit_processors.js
@@ -107,6 +107,29 @@ async function main() {
     console.log("You are signing the following transaction: Dispenser.connect(EOA).setDepositProcessorChainIds()");
     const result = await dispenser.connect(EOA).setDepositProcessorChainIds(depositProcessors, chainIds);
     console.log("Transaction:", result.hash);
+
+    // Await the receipt. Submitting is not succeeding: with the Dispenser Timelock-owned, OwnerOnly is the
+    // likeliest failure here, and it reverts AFTER submission - so without this the script would print a
+    // hash and exit 0 on a transaction that did nothing.
+    const receipt = await result.wait();
+    if (receipt.status !== 1) {
+        throw new Error(`setDepositProcessorChainIds reverted in ${result.hash}`);
+    }
+
+    // Read back every route, mirroring deploy_10_set_deposit_processors.sh. A partially registered Dispenser
+    // is the exact state the hard-fail guards above exist to prevent, so it is verified rather than assumed.
+    let mismatch = false;
+    for (let i = 0; i < depositProcessors.length; i++) {
+        const onchain = await dispenser.mapChainIdDepositProcessors(chainIds[i]);
+        if (onchain.toLowerCase() !== depositProcessors[i].toLowerCase()) {
+            console.error(`  chainId ${chainIds[i]}: on-chain ${onchain} != ${depositProcessors[i]}`);
+            mismatch = true;
+        }
+    }
+    if (mismatch) {
+        throw new Error("One or more deposit processors did not take effect");
+    }
+    console.log("All deposit processors whitelisted");
 }
 
 main()

--- a/scripts/deployment/staking/deploy_10_set_deposit_processors.js
+++ b/scripts/deployment/staking/deploy_10_set_deposit_processors.js
@@ -1,34 +1,61 @@
 /*global process*/
 /*
- * NOTE: this script does NOT register the Mode processor.
+ * Registers every L1 deposit processor in the Dispenser.
  *
- * Mode's L1 processor is deployed at step 11, after this step runs, so its address does not exist
- * yet here. `deploy_10_set_deposit_processors.sh` is the current equivalent and registers all eight
- * routes including Mode; prefer it. A chain left unregistered resolves to a zero processor and
- * reverts the claim - in the batch path it takes the other chains' claims down with it - so a
- * fresh deployment that uses this script must register Mode separately afterwards.
+ * ORDERING: despite the file number, this is a terminal step rather than step 10 of a linear run.
+ * Mode's L1 processor is deployed at step 11 and Robinhood's at step 13, so this must run only once
+ * every per-chain processor deploy has completed. It hard-fails on a missing or zero entry rather
+ * than registering a partial set: a chain left unregistered resolves to a zero processor and reverts
+ * the claim, and in the batch path it takes the other chains' claims down with it.
+ *
+ * `deploy_10_set_deposit_processors.sh` is the equivalent shell route and is the preferred one.
  */
-
 
 const { ethers } = require("hardhat");
 const { LedgerSigner } = require("@anders-t/ethers-ledger");
+
+// Processor rows: label, globals key holding the address, globals key holding the L2 target chain Id.
+// The Ethereum row is L1-only, so its chain Id is the network's own rather than a globals key.
+const PROCESSOR_ROWS = [
+    ["Arbitrum", "arbitrumDepositProcessorL1Address", "arbitrumL2TargetChainId"],
+    ["Base", "baseDepositProcessorL1Address", "baseL2TargetChainId"],
+    ["Celo", "celoDepositProcessorL1Address", "celoL2TargetChainId"],
+    ["Gnosis", "gnosisDepositProcessorL1Address", "gnosisL2TargetChainId"],
+    ["Mode", "modeDepositProcessorL1Address", "modeL2TargetChainId"],
+    ["Optimism", "optimismDepositProcessorL1Address", "optimismL2TargetChainId"],
+    ["Polygon", "polygonDepositProcessorL1Address", "polygonL2TargetChainId"],
+    ["Robinhood", "robinhoodDepositProcessorL1Address", "robinhoodL2TargetChainId"],
+    ["Ethereum", "ethereumDepositProcessorAddress", null]
+];
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+function requireAddress(parsedData, label, key) {
+    const value = parsedData[key];
+    if (!value || value === ZERO_ADDRESS) {
+        throw new Error(`${label}: ${key} is not set (or zero) in globals.json. Every processor must be ` +
+            "deployed before this step runs - see the ordering note at the top of this file.");
+    }
+    return value;
+}
+
+function requireChainId(parsedData, label, key) {
+    const value = parsedData[key];
+    if (!value || Number(value) === 0) {
+        throw new Error(`${label}: ${key} is not set (or zero) in globals.json.`);
+    }
+    return value;
+}
 
 async function main() {
     const fs = require("fs");
     const globalsFile = "globals.json";
     const dataFromJSON = fs.readFileSync(globalsFile, "utf8");
-    let parsedData = JSON.parse(dataFromJSON);
+    const parsedData = JSON.parse(dataFromJSON);
     const useLedger = parsedData.useLedger;
     const derivationPath = parsedData.derivationPath;
     const providerName = parsedData.providerName;
-    const arbitrumDepositProcessorL1Address = parsedData.arbitrumDepositProcessorL1Address;
-    const baseDepositProcessorL1Address = parsedData.baseDepositProcessorL1Address;
-    const celoDepositProcessorL1Address = parsedData.celoDepositProcessorL1Address;
-    const gnosisDepositProcessorL1Address = parsedData.gnosisDepositProcessorL1Address;
-    const optimismDepositProcessorL1Address = parsedData.optimismDepositProcessorL1Address;
-    const polygonDepositProcessorL1Address = parsedData.polygonDepositProcessorL1Address;
-    const ethereumDepositProcessorAddress = parsedData.ethereumDepositProcessorAddress;
-    const dispenserProxyAddress = parsedData.dispenserProxyAddress;
+    const dispenserProxyAddress = requireAddress(parsedData, "Dispenser", "dispenserProxyAddress");
     let EOA;
 
     const provider = await ethers.providers.getDefaultProvider(providerName);
@@ -43,24 +70,25 @@ async function main() {
     const deployer = await EOA.getAddress();
     console.log("EOA is:", deployer);
 
-    // Get all the contracts
-    const arbitrumDepositProcessorL1 = await ethers.getContractAt("ArbitrumDepositProcessorL1", arbitrumDepositProcessorL1Address);
-    const baseDepositProcessorL1 = await ethers.getContractAt("OptimismDepositProcessorL1", baseDepositProcessorL1Address);
-    const celoDepositProcessorL1 = await ethers.getContractAt("OptimismDepositProcessorL1", celoDepositProcessorL1Address);
-    const gnosisDepositProcessorL1 = await ethers.getContractAt("GnosisDepositProcessorL1", gnosisDepositProcessorL1Address);
-    const optimismDepositProcessorL1 = await ethers.getContractAt("OptimismDepositProcessorL1", optimismDepositProcessorL1Address);
-    const polygonDepositProcessorL1 = await ethers.getContractAt("PolygonDepositProcessorL1", polygonDepositProcessorL1Address);
+    const ethereumChainId = (await provider.getNetwork()).chainId;
+
+    // Build the two aligned arrays, hard-failing on any missing or zero entry
+    const depositProcessors = [];
+    const chainIds = [];
+    for (const [label, addressKey, chainIdKey] of PROCESSOR_ROWS) {
+        const depositProcessor = requireAddress(parsedData, label, addressKey);
+        const chainId = chainIdKey === null ? ethereumChainId : requireChainId(parsedData, label, chainIdKey);
+        depositProcessors.push(depositProcessor);
+        chainIds.push(chainId);
+        console.log(`  ${label}: ${depositProcessor} -> chainId ${chainId}`);
+    }
+
     const dispenser = await ethers.getContractAt("Dispenser", dispenserProxyAddress);
 
     // Transaction signing and execution
     console.log("10. EOA to set deposit processors in Dispenser");
     console.log("You are signing the following transaction: Dispenser.connect(EOA).setDepositProcessorChainIds()");
-    const ethereumChainId = (await provider.getNetwork()).chainId;
-    const result = await dispenser.connect(EOA).setDepositProcessorChainIds([arbitrumDepositProcessorL1Address,
-        baseDepositProcessorL1Address, celoDepositProcessorL1Address, ethereumDepositProcessorAddress,
-        gnosisDepositProcessorL1Address, optimismDepositProcessorL1Address, polygonDepositProcessorL1Address],
-    [parsedData.arbitrumL2TargetChainId, parsedData.baseL2TargetChainId, parsedData.celoL2TargetChainId, ethereumChainId,
-        parsedData.gnosisL2TargetChainId, parsedData.optimismL2TargetChainId, parsedData.polygonL2TargetChainId]);
+    const result = await dispenser.connect(EOA).setDepositProcessorChainIds(depositProcessors, chainIds);
     console.log("Transaction:", result.hash);
 }
 

--- a/scripts/deployment/staking/deploy_10_set_deposit_processors.sh
+++ b/scripts/deployment/staking/deploy_10_set_deposit_processors.sh
@@ -68,6 +68,7 @@ rows=(
   "Optimism optimismDepositProcessorL1Address optimismL2TargetChainId"
   "Polygon polygonDepositProcessorL1Address polygonL2TargetChainId"
   "Mode modeDepositProcessorL1Address modeL2TargetChainId"
+  "Robinhood robinhoodDepositProcessorL1Address robinhoodL2TargetChainId"
   "Ethereum ethereumDepositProcessorAddress __L1__"
 )
 

--- a/scripts/deployment/staking/deploy_10_set_deposit_processors.sh
+++ b/scripts/deployment/staking/deploy_10_set_deposit_processors.sh
@@ -50,6 +50,9 @@ chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 dispenserProxyAddress=$(jq -r '.dispenserProxyAddress' $globals)
 
+# Preflight: cross-check the Dispenser binding (see _preflight_dispenser.sh).
+. "$(dirname "$0")/_preflight_dispenser.sh"
+
 zeroAddress="0x0000000000000000000000000000000000000000"
 
 if [ -z "$dispenserProxyAddress" ] || [ "$dispenserProxyAddress" == "null" ] \

--- a/scripts/deployment/staking/deploy_11_mode_deposit_processor.sh
+++ b/scripts/deployment/staking/deploy_11_mode_deposit_processor.sh
@@ -27,6 +27,9 @@ networkURL=$(jq -r '.networkURL' $globals)
 
 olasAddress=$(jq -r '.olasAddress' $globals)
 dispenserProxyAddress=$(jq -r '.dispenserProxyAddress' $globals)
+
+# Preflight: cross-check the Dispenser binding (see _preflight_dispenser.sh).
+. "$(dirname "$0")/_preflight_dispenser.sh"
 modeL1StandardBridgeProxyAddress=$(jq -r '.modeL1StandardBridgeProxyAddress' $globals)
 modeL1CrossDomainMessengerProxyAddress=$(jq -r '.modeL1CrossDomainMessengerProxyAddress' $globals)
 modeL2TargetChainId=$(jq -r '.modeL2TargetChainId' $globals)

--- a/scripts/deployment/staking/deploy_13_robinhood_deposit_processor.sh
+++ b/scripts/deployment/staking/deploy_13_robinhood_deposit_processor.sh
@@ -8,14 +8,14 @@ reset=$(tput sgr0)
 globals="$(dirname "$0")/globals_$1.json"
 if [ ! -f $globals ]; then
   echo "${red}!!! $globals is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Get globals file for L2
 globalsL2="$(dirname "$0")/robinhood/globals_robinhood_$1.json"
 if [ ! -f $globalsL2 ]; then
   echo "${red}!!! $globalsL2 is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Read variables using jq
@@ -33,6 +33,29 @@ robinhoodL2TargetChainId=$(jq -r '.robinhoodL2TargetChainId' $globals)
 robinhoodL1ERC20GatewayAddress=$(jq -r '.robinhoodL1ERC20GatewayAddress' $globals)
 robinhoodOutboxAddress=$(jq -r '.robinhoodOutboxAddress' $globals)
 robinhoodBridgeAddress=$(jq -r '.robinhoodBridgeAddress' $globals)
+
+# Preflight on the Dispenser binding. l1Dispenser is `immutable` in DefaultDepositProcessorL1, so a processor
+# deployed against the wrong Dispenser cannot be repaired — claims from the live one revert ManagerOnly.
+# deploy_07b_dispenser_proxy.sh writes dispenserProxyAddress into scripts/deployment/globals_<network>.json,
+# a DIFFERENT file from this one, so a proxy migration silently leaves the value here stale.
+zeroAddress="0x0000000000000000000000000000000000000000"
+if [ -z "$dispenserProxyAddress" ] || [ "$dispenserProxyAddress" == "null" ] \
+   || [ "$dispenserProxyAddress" == "$zeroAddress" ]; then
+  echo "${red}!!! dispenserProxyAddress is not set (or zero) in $globals${reset}"
+  exit 1
+fi
+deploymentGlobals="$(dirname "$0")/../globals_${1}.json"
+if [ -f "$deploymentGlobals" ]; then
+  liveDispenser=$(jq -r '.dispenserProxyAddress // .dispenserAddress // empty' "$deploymentGlobals")
+  if [ -n "$liveDispenser" ] \
+     && [ "$(echo "$liveDispenser" | tr '[:upper:]' '[:lower:]')" != "$(echo "$dispenserProxyAddress" | tr '[:upper:]' '[:lower:]')" ]; then
+    echo "${red}!!! Dispenser binding mismatch — refusing to deploy an immutable binding to a stale address${reset}"
+    echo "${red}    $globals            dispenserProxyAddress = $dispenserProxyAddress${reset}"
+    echo "${red}    $deploymentGlobals  says the live Dispenser is $liveDispenser${reset}"
+    echo "${red}    Reconcile the two before deploying; l1Dispenser cannot be changed afterwards.${reset}"
+    exit 1
+  fi
+fi
 
 
 # Check for Alchemy keys
@@ -79,7 +102,7 @@ outputLength=${#robinhoodDepositProcessorL1Address}
 # Check for the deployed address
 if [ $outputLength != 42 ]; then
   echo "${red}!!! The contract was not deployed...${reset}"
-  exit 0
+  exit 1
 fi
 
 # Write new deployed contract back into JSON

--- a/scripts/deployment/staking/deploy_13_robinhood_deposit_processor.sh
+++ b/scripts/deployment/staking/deploy_13_robinhood_deposit_processor.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+red=$(tput setaf 1)
+green=$(tput setaf 2)
+reset=$(tput sgr0)
+
+# Get globals file
+globals="$(dirname "$0")/globals_$1.json"
+if [ ! -f $globals ]; then
+  echo "${red}!!! $globals is not found${reset}"
+  exit 0
+fi
+
+# Get globals file for L2
+globalsL2="$(dirname "$0")/robinhood/globals_robinhood_$1.json"
+if [ ! -f $globalsL2 ]; then
+  echo "${red}!!! $globalsL2 is not found${reset}"
+  exit 0
+fi
+
+# Read variables using jq
+contractVerification=$(jq -r '.contractVerification' $globals)
+useLedger=$(jq -r '.useLedger' $globals)
+derivationPath=$(jq -r '.derivationPath' $globals)
+chainId=$(jq -r '.chainId' $globals)
+networkURL=$(jq -r '.networkURL' $globals)
+
+olasAddress=$(jq -r '.olasAddress' $globals)
+dispenserProxyAddress=$(jq -r '.dispenserProxyAddress' $globals)
+robinhoodL1ERC20GatewayRouterAddress=$(jq -r '.robinhoodL1ERC20GatewayRouterAddress' $globals)
+robinhoodInboxAddress=$(jq -r '.robinhoodInboxAddress' $globals)
+robinhoodL2TargetChainId=$(jq -r '.robinhoodL2TargetChainId' $globals)
+robinhoodL1ERC20GatewayAddress=$(jq -r '.robinhoodL1ERC20GatewayAddress' $globals)
+robinhoodOutboxAddress=$(jq -r '.robinhoodOutboxAddress' $globals)
+robinhoodBridgeAddress=$(jq -r '.robinhoodBridgeAddress' $globals)
+
+
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
+  fi
+fi
+
+contractPath="contracts/staking/ArbitrumDepositProcessorL1.sol:ArbitrumDepositProcessorL1"
+constructorArgs="$olasAddress $dispenserProxyAddress $robinhoodL1ERC20GatewayRouterAddress $robinhoodInboxAddress $robinhoodL2TargetChainId $robinhoodL1ERC20GatewayAddress $robinhoodOutboxAddress $robinhoodBridgeAddress"
+contractArgs="$contractPath --constructor-args $constructorArgs"
+
+# Get deployer based on the ledger flag
+if [ "$useLedger" == "true" ]; then
+  walletArgs="-l --mnemonic-derivation-path $derivationPath"
+  deployer=$(cast wallet address $walletArgs)
+else
+  echo "Using PRIVATE_KEY: ${PRIVATE_KEY:0:6}..."
+  walletArgs="--private-key $PRIVATE_KEY"
+  deployer=$(cast wallet address $walletArgs)
+fi
+
+# Deployment message
+echo "${green}Deploying from: $deployer${reset}"
+echo "RPC: $networkURL"
+echo "${green}Deployment of: $contractArgs${reset}"
+
+# Deploy the contract and capture the address
+execCmd="forge create --broadcast --rpc-url $networkURL$API_KEY $walletArgs $contractArgs"
+deploymentOutput=$($execCmd)
+robinhoodDepositProcessorL1Address=$(echo "$deploymentOutput" | grep 'Deployed to:' | awk '{print $3}')
+
+# Get output length
+outputLength=${#robinhoodDepositProcessorL1Address}
+
+# Check for the deployed address
+if [ $outputLength != 42 ]; then
+  echo "${red}!!! The contract was not deployed...${reset}"
+  exit 0
+fi
+
+# Write new deployed contract back into JSON
+echo "$(jq '. += {"robinhoodDepositProcessorL1Address":"'$robinhoodDepositProcessorL1Address'"}' $globals)" > $globals
+# Also write the address into corresponding L2 JSON
+echo "$(jq '. += {"robinhoodDepositProcessorL1Address":"'$robinhoodDepositProcessorL1Address'"}' $globalsL2)" > $globalsL2
+
+# Verify contract
+if [ "$contractVerification" == "true" ]; then
+  contractParams="$robinhoodDepositProcessorL1Address $contractPath --constructor-args $(cast abi-encode "constructor(address,address,address,address,uint256,address,address,address)" $constructorArgs)"
+  echo "Verification contract params: $contractParams"
+
+  echo "${green}Verifying contract on Etherscan...${reset}"
+  forge verify-contract --chain-id "$chainId" --etherscan-api-key "$ETHERSCAN_API_KEY" $contractParams
+
+  blockscoutURL=$(jq -r '.blockscoutURL' $globals)
+  if [ "$blockscoutURL" != "null" ]; then
+    echo "${green}Verifying contract on Blockscout...${reset}"
+    forge verify-contract --verifier blockscout --verifier-url "$blockscoutURL/api" $contractParams
+  fi
+fi
+
+echo "${green}Contract deployed at: $robinhoodDepositProcessorL1Address${reset}"

--- a/scripts/deployment/staking/deploy_13_robinhood_deposit_processor.sh
+++ b/scripts/deployment/staking/deploy_13_robinhood_deposit_processor.sh
@@ -34,6 +34,16 @@ robinhoodL1ERC20GatewayAddress=$(jq -r '.robinhoodL1ERC20GatewayAddress' $global
 robinhoodOutboxAddress=$(jq -r '.robinhoodOutboxAddress' $globals)
 robinhoodBridgeAddress=$(jq -r '.robinhoodBridgeAddress' $globals)
 
+# Preflight: cross-check the Dispenser binding (see _preflight_dispenser.sh).
+. "$(dirname "$0")/_preflight_dispenser.sh"
+
+robinhoodL1ERC20GatewayRouterAddress=$(jq -r '.robinhoodL1ERC20GatewayRouterAddress' $globals)
+robinhoodInboxAddress=$(jq -r '.robinhoodInboxAddress' $globals)
+robinhoodL2TargetChainId=$(jq -r '.robinhoodL2TargetChainId' $globals)
+robinhoodL1ERC20GatewayAddress=$(jq -r '.robinhoodL1ERC20GatewayAddress' $globals)
+robinhoodOutboxAddress=$(jq -r '.robinhoodOutboxAddress' $globals)
+robinhoodBridgeAddress=$(jq -r '.robinhoodBridgeAddress' $globals)
+
 # Preflight on the Dispenser binding. l1Dispenser is `immutable` in DefaultDepositProcessorL1, so a processor
 # deployed against the wrong Dispenser cannot be repaired — claims from the live one revert ManagerOnly.
 # deploy_07b_dispenser_proxy.sh writes dispenserProxyAddress into scripts/deployment/globals_<network>.json,

--- a/scripts/deployment/staking/globals_mainnet.json
+++ b/scripts/deployment/staking/globals_mainnet.json
@@ -65,7 +65,6 @@
   "robinhoodInboxAddress": "0x1A07cc4BD17E0118BdB54D70990D2158AbAD7a2D",
   "robinhoodOutboxAddress": "0xf0ce991ea4A0d2400A4AB49b20ae333f6Dce3DE9",
   "robinhoodBridgeAddress": "0xDf8755334ce7A73cCF6b581C02eA649AE3E864b3",
-  "robinhoodOLASAddress": "0x092963938DEBd8013a2E545B3549f8a5EC0d2286",
   "robinhoodL2TargetChainId": "4663",
   "robinhoodDepositProcessorL1Address": "",
   "robinhoodTargetDispenserL2Address": ""

--- a/scripts/deployment/staking/globals_mainnet.json
+++ b/scripts/deployment/staking/globals_mainnet.json
@@ -58,5 +58,15 @@
   "modeOLASAddress": "0xcfD1D50ce23C46D3Cf6407487B2F8934e96DC8f9",
   "modeL2TargetChainId": "34443",
   "modeDepositProcessorL1Address": "0x6A5F38aAdCc1c049E39D80147b64a9Ff947d208B",
-  "modeTargetDispenserL2Address": "0xEB5638eefE289691EcE01943f768EDBF96258a80"
+  "modeTargetDispenserL2Address": "0xEB5638eefE289691EcE01943f768EDBF96258a80",
+  "dispenserProxyAddress": "0x5650300fCBab43A0D7D02F8Cb5d0f039402593f0",
+  "robinhoodL1ERC20GatewayRouterAddress": "0x6a2E3a1e16FC29f27Ce61429746D558d656975bB",
+  "robinhoodL1ERC20GatewayAddress": "0x85001CC4867C5e1C22dA4B79BB8852B9e2a06da0",
+  "robinhoodInboxAddress": "0x1A07cc4BD17E0118BdB54D70990D2158AbAD7a2D",
+  "robinhoodOutboxAddress": "0xf0ce991ea4A0d2400A4AB49b20ae333f6Dce3DE9",
+  "robinhoodBridgeAddress": "0xDf8755334ce7A73cCF6b581C02eA649AE3E864b3",
+  "robinhoodOLASAddress": "0x092963938DEBd8013a2E545B3549f8a5EC0d2286",
+  "robinhoodL2TargetChainId": "4663",
+  "robinhoodDepositProcessorL1Address": "",
+  "robinhoodTargetDispenserL2Address": ""
 }

--- a/scripts/deployment/staking/robinhood/deploy_02_robinhood_target_dispenser.sh
+++ b/scripts/deployment/staking/robinhood/deploy_02_robinhood_target_dispenser.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+red=$(tput setaf 1)
+green=$(tput setaf 2)
+reset=$(tput sgr0)
+
+# Get globals file
+globals="$(dirname "$0")/globals_$1.json"
+if [ ! -f $globals ]; then
+  echo "${red}!!! $globals is not found${reset}"
+  exit 0
+fi
+
+# Get globals file for L1: globals_mainnet or globals_sepolia
+globalsL1="$(dirname "$0")/../globals_${1#*_}.json"
+if [ ! -f $globalsL1 ]; then
+  echo "${red}!!! $globalsL1 is not found${reset}"
+  exit 0
+fi
+
+# Read variables using jq
+contractVerification=$(jq -r '.contractVerification' $globals)
+useLedger=$(jq -r '.useLedger' $globals)
+derivationPath=$(jq -r '.derivationPath' $globals)
+chainId=$(jq -r '.chainId' $globals)
+networkURL=$(jq -r '.networkURL' $globals)
+
+olasAddress=$(jq -r '.olasAddress' $globals)
+serviceStakingFactoryAddress=$(jq -r '.serviceStakingFactoryAddress' $globals)
+robinhoodArbSysAddress=$(jq -r '.robinhoodArbSysAddress' $globals)
+robinhoodDepositProcessorL1Address=$(jq -r '.robinhoodDepositProcessorL1Address' $globals)
+l1ChainId=$(jq -r '.l1ChainId' $globals)
+
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
+  fi
+fi
+
+contractPath="contracts/staking/ArbitrumTargetDispenserL2.sol:ArbitrumTargetDispenserL2"
+constructorArgs="$olasAddress $serviceStakingFactoryAddress $robinhoodArbSysAddress $robinhoodDepositProcessorL1Address $l1ChainId"
+contractArgs="$contractPath --constructor-args $constructorArgs"
+
+# Get deployer based on the ledger flag
+if [ "$useLedger" == "true" ]; then
+  walletArgs="-l --mnemonic-derivation-path $derivationPath"
+  deployer=$(cast wallet address $walletArgs)
+else
+  echo "Using PRIVATE_KEY: ${PRIVATE_KEY:0:6}..."
+  walletArgs="--private-key $PRIVATE_KEY"
+  deployer=$(cast wallet address $walletArgs)
+fi
+
+# Deployment message
+echo "${green}Deploying from: $deployer${reset}"
+echo "RPC: $networkURL"
+echo "${green}Deployment of: $contractArgs${reset}"
+
+# Deploy the contract and capture the address
+execCmd="forge create --broadcast --rpc-url $networkURL$API_KEY $walletArgs $contractArgs"
+deploymentOutput=$($execCmd)
+robinhoodTargetDispenserL2Address=$(echo "$deploymentOutput" | grep 'Deployed to:' | awk '{print $3}')
+
+# Get output length
+outputLength=${#robinhoodTargetDispenserL2Address}
+
+# Check for the deployed address
+if [ $outputLength != 42 ]; then
+  echo "${red}!!! The contract was not deployed...${reset}"
+  exit 0
+fi
+
+# Write new deployed contract back into JSON
+echo "$(jq '. += {"robinhoodTargetDispenserL2Address":"'$robinhoodTargetDispenserL2Address'"}' $globals)" > $globals
+# Also write the address into corresponding L1 JSON
+echo "$(jq '. += {"robinhoodTargetDispenserL2Address":"'$robinhoodTargetDispenserL2Address'"}' $globalsL1)" > $globalsL1
+
+# Verify contract
+if [ "$contractVerification" == "true" ]; then
+  contractParams="$robinhoodTargetDispenserL2Address $contractPath --constructor-args $(cast abi-encode "constructor(address,address,address,address,uint256)" $constructorArgs)"
+  echo "Verification contract params: $contractParams"
+
+  echo "${green}Verifying contract on Etherscan...${reset}"
+  forge verify-contract --chain-id "$chainId" --etherscan-api-key "$ETHERSCAN_API_KEY" $contractParams
+
+  blockscoutURL=$(jq -r '.blockscoutURL' $globals)
+  if [ "$blockscoutURL" != "null" ]; then
+    echo "${green}Verifying contract on Blockscout...${reset}"
+    forge verify-contract --verifier blockscout --verifier-url "$blockscoutURL/api" $contractParams
+  fi
+fi
+
+echo "${green}Contract deployed at: $robinhoodTargetDispenserL2Address${reset}"

--- a/scripts/deployment/staking/robinhood/deploy_02_robinhood_target_dispenser.sh
+++ b/scripts/deployment/staking/robinhood/deploy_02_robinhood_target_dispenser.sh
@@ -8,14 +8,14 @@ reset=$(tput sgr0)
 globals="$(dirname "$0")/globals_$1.json"
 if [ ! -f $globals ]; then
   echo "${red}!!! $globals is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Get globals file for L1: globals_mainnet or globals_sepolia
 globalsL1="$(dirname "$0")/../globals_${1#*_}.json"
 if [ ! -f $globalsL1 ]; then
   echo "${red}!!! $globalsL1 is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Read variables using jq
@@ -75,7 +75,7 @@ outputLength=${#robinhoodTargetDispenserL2Address}
 # Check for the deployed address
 if [ $outputLength != 42 ]; then
   echo "${red}!!! The contract was not deployed...${reset}"
-  exit 0
+  exit 1
 fi
 
 # Write new deployed contract back into JSON

--- a/scripts/deployment/staking/robinhood/deploy_02_robinhood_target_dispenser.sh
+++ b/scripts/deployment/staking/robinhood/deploy_02_robinhood_target_dispenser.sh
@@ -31,6 +31,24 @@ robinhoodArbSysAddress=$(jq -r '.robinhoodArbSysAddress' $globals)
 robinhoodDepositProcessorL1Address=$(jq -r '.robinhoodDepositProcessorL1Address' $globals)
 l1ChainId=$(jq -r '.l1ChainId' $globals)
 
+# Validate every constructor input before building the args. `--constructor-args $constructorArgs` is
+# unquoted, so an empty value is collapsed by word-splitting rather than passed as an empty token: the
+# constructor would silently receive four arguments instead of five. That fails at forge's arity check today,
+# but a stale-but-well-formed address would deploy successfully against a wrong IMMUTABLE binding —
+# l1DepositProcessor is aliased into an immutable field and cannot be corrected afterwards.
+zeroAddress="0x0000000000000000000000000000000000000000"
+for pair in "olasAddress:$olasAddress" \
+            "serviceStakingFactoryAddress:$serviceStakingFactoryAddress" \
+            "robinhoodArbSysAddress:$robinhoodArbSysAddress" \
+            "robinhoodDepositProcessorL1Address:$robinhoodDepositProcessorL1Address" \
+            "l1ChainId:$l1ChainId"; do
+  key="${pair%%:*}"; val="${pair#*:}"
+  if [ -z "$val" ] || [ "$val" == "null" ] || [ "$val" == "$zeroAddress" ] || [ "$val" == "0" ]; then
+    echo "${red}!!! $key is not set (or zero) in $globals${reset}"
+    exit 1
+  fi
+done
+
 # Check for Alchemy keys
 if [[ "$networkURL" == *"alchemy.com"* ]]; then
   case $chainId in

--- a/scripts/deployment/staking/robinhood/globals_robinhood_mainnet.json
+++ b/scripts/deployment/staking/robinhood/globals_robinhood_mainnet.json
@@ -10,8 +10,8 @@
   "olasAddress": "0x092963938DEBd8013a2E545B3549f8a5EC0d2286",
   "serviceStakingFactoryAddress": "",
   "bridgeMediatorAddress": "0x4d30F68F5AA342d296d4deE4bB1Cacca912dA70F",
-  "arbitrumArbSysAddress": "0x0000000000000000000000000000000000000064",
+  "robinhoodArbSysAddress": "0x0000000000000000000000000000000000000064",
   "l1ChainId": "1",
-  "arbitrumDepositProcessorL1Address": "",
-  "arbitrumTargetDispenserL2Address": ""
+  "robinhoodDepositProcessorL1Address": "",
+  "robinhoodTargetDispenserL2Address": ""
 }

--- a/scripts/deployment/staking/robinhood/globals_robinhood_mainnet.json
+++ b/scripts/deployment/staking/robinhood/globals_robinhood_mainnet.json
@@ -7,7 +7,7 @@
   "networkURL": "https://rpc.mainnet.chain.robinhood.com",
   "blockscoutURL": "https://robinhoodchain.blockscout.com",
   "gasPriceInGwei": "1",
-  "olasAddress": "0x092963938DEBd8013a2E545B3549f8a5EC0d2286",
+  "olasAddress": "0x092963938deBD8013a2e545b3549f8A5ec0D2286",
   "serviceStakingFactoryAddress": "",
   "bridgeMediatorAddress": "0x4d30F68F5AA342d296d4deE4bB1Cacca912dA70F",
   "robinhoodArbSysAddress": "0x0000000000000000000000000000000000000064",


### PR DESCRIPTION
Config only, two parts.

## 1. Robinhood Chain (4663) globals

Robinhood Chain is an Arbitrum Orbit rollup settling to Ethereum with ETH gas, so it reuses `ArbitrumDepositProcessorL1` and `ArbitrumTargetDispenserL2` **unchanged**. All values verified against the live chains on 2026-09-06.

**L2** — `staking/arbitrum/globals_robinhood_mainnet.json`. `deploy_02_arbitrum_target_dispenser.sh` takes the globals suffix as `$1`, so `./deploy_02_arbitrum_target_dispenser.sh robinhood_mainnet` works with **no script change**. The `arbitrum*` key names hold Robinhood values — accurate for the bridge family, but worth knowing when reading the file.

**L1** — a `robinhood*` block in `staking/globals_mainnet.json`, following the per-chain prefixed convention already used for gnosis/optimism/celo/polygon/base/mode.

⚠️ **Six of the eight `ArbitrumDepositProcessorL1` constructor arguments are Robinhood-specific.** Reusing an Arbitrum One value would route funds into Arbitrum's escrow under a 4663 chain tag — a silent, unrecoverable mis-send. Diff the constructor args against the deployed Arbitrum processor before broadcasting; six of eight must differ.

Note `bridgeMediatorAddress` on the L2 file is byte-identical to Arbitrum's. That is correct — same L1 Timelock, and address aliasing is chain-independent.

## 2. `dispenserProxyAddress` was missing entirely — this affects every chain

`deploy_02_arbitrum_deposit_processor` (both `.js` and `.sh`) and `deploy_10_set_deposit_processors` all read **`dispenserProxyAddress`**, but **no globals file in the tree defines it**. `globals_mainnet.json` carries the value under `dispenserAddress`.

So `jq -r '.dispenserProxyAddress'` returns `null`, the processor is deployed with a zero `_l1Dispenser`, and `DefaultDepositProcessorL1`'s constructor reverts:

```solidity
if (_l1Dispenser == address(0) || _l1TokenRelayer == address(0) || _l1MessageRelayer == address(0)) {
    revert ZeroAddress();
}
```

This is not Robinhood-specific — the L1 deposit-processor path is broken for any chain today. Added alongside the existing `dispenserAddress` rather than renaming, so nothing that reads the old key breaks.

## Still outstanding — script changes, not config, so not in this PR

1. **`deploy_02_arbitrum_deposit_processor.sh` cannot deploy the Robinhood processor.** It reads `arbitrum*`-prefixed keys and writes back `arbitrumDepositProcessorL1Address`, so running it for 4663 would clobber Arbitrum One's recorded address. A `robinhood` variant of the script is needed.
2. **`deploy_10_set_deposit_processors.js` registers seven chains and omits both mode and robinhood.** The Mode gap is already tracked as `OLAS1-145` — the live mapping was completed by hand. A fresh Dispenser deployment would reproduce neither route.

Happy to follow up with both if you'd like them in the same cycle.
