### PR TITLE
fix(staking): propagate deploy failures instead of reporting success

### DIFF
--- a/scripts/deployment/staking/arbitrum/deploy_02_arbitrum_target_dispenser.sh
+++ b/scripts/deployment/staking/arbitrum/deploy_02_arbitrum_target_dispenser.sh
@@ -8,14 +8,14 @@ reset=$(tput sgr0)
 globals="$(dirname "$0")/globals_$1.json"
 if [ ! -f $globals ]; then
   echo "${red}!!! $globals is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Get globals file for L1: globals_mainnet or globals_sepolia
 globalsL1="$(dirname "$0")/../globals_${1#*_}.json"
 if [ ! -f $globalsL1 ]; then
   echo "${red}!!! $globalsL1 is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Read variables using jq
@@ -41,7 +41,7 @@ if [[ "$networkURL" == *"alchemy.com"* ]]; then
   esac
   if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
     echo "set $keyName env variable"
-    exit 0
+    exit 1
   fi
 fi
 
@@ -75,7 +75,7 @@ outputLength=${#arbitrumTargetDispenserL2Address}
 # Check for the deployed address
 if [ $outputLength != 42 ]; then
   echo "${red}!!! The contract was not deployed...${reset}"
-  exit 0
+  exit 1
 fi
 
 # Write new deployed contract back into JSON

--- a/scripts/deployment/staking/base/deploy_07_base_target_dispenser.sh
+++ b/scripts/deployment/staking/base/deploy_07_base_target_dispenser.sh
@@ -8,14 +8,14 @@ reset=$(tput sgr0)
 globals="$(dirname "$0")/globals_$1.json"
 if [ ! -f $globals ]; then
   echo "${red}!!! $globals is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Get globals file for L1: globals_mainnet or globals_sepolia
 globalsL1="$(dirname "$0")/../globals_${1#*_}.json"
 if [ ! -f $globalsL1 ]; then
   echo "${red}!!! $globalsL1 is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Read variables using jq
@@ -41,7 +41,7 @@ if [[ "$networkURL" == *"alchemy.com"* ]]; then
   esac
   if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
     echo "set $keyName env variable"
-    exit 0
+    exit 1
   fi
 fi
 
@@ -75,7 +75,7 @@ outputLength=${#baseTargetDispenserL2Address}
 # Check for the deployed address
 if [ $outputLength != 42 ]; then
   echo "${red}!!! The contract was not deployed...${reset}"
-  exit 0
+  exit 1
 fi
 
 # Write new deployed contract back into JSON

--- a/scripts/deployment/staking/celo/deploy_05_celo_target_dispenser.sh
+++ b/scripts/deployment/staking/celo/deploy_05_celo_target_dispenser.sh
@@ -8,14 +8,14 @@ reset=$(tput sgr0)
 globals="$(dirname "$0")/globals_$1.json"
 if [ ! -f $globals ]; then
   echo "${red}!!! $globals is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Get globals file for L1: globals_mainnet or globals_sepolia
 globalsL1="$(dirname "$0")/../globals_${1#*_}.json"
 if [ ! -f $globalsL1 ]; then
   echo "${red}!!! $globalsL1 is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Read variables using jq
@@ -41,7 +41,7 @@ if [[ "$networkURL" == *"alchemy.com"* ]]; then
   esac
   if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
     echo "set $keyName env variable"
-    exit 0
+    exit 1
   fi
 fi
 
@@ -75,7 +75,7 @@ outputLength=${#celoTargetDispenserL2Address}
 # Check for the deployed address
 if [ $outputLength != 42 ]; then
   echo "${red}!!! The contract was not deployed...${reset}"
-  exit 0
+  exit 1
 fi
 
 # Write new deployed contract back into JSON

--- a/scripts/deployment/staking/deploy_02_arbitrum_deposit_processor.sh
+++ b/scripts/deployment/staking/deploy_02_arbitrum_deposit_processor.sh
@@ -8,14 +8,14 @@ reset=$(tput sgr0)
 globals="$(dirname "$0")/globals_$1.json"
 if [ ! -f $globals ]; then
   echo "${red}!!! $globals is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Get globals file for L2
 globalsL2="$(dirname "$0")/arbitrum/globals_arbitrum_$1.json"
 if [ ! -f $globalsL2 ]; then
   echo "${red}!!! $globalsL2 is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Read variables using jq
@@ -45,7 +45,7 @@ if [[ "$networkURL" == *"alchemy.com"* ]]; then
   esac
   if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
     echo "set $keyName env variable"
-    exit 0
+    exit 1
   fi
 fi
 
@@ -79,7 +79,7 @@ outputLength=${#arbitrumDepositProcessorL1Address}
 # Check for the deployed address
 if [ $outputLength != 42 ]; then
   echo "${red}!!! The contract was not deployed...${reset}"
-  exit 0
+  exit 1
 fi
 
 # Write new deployed contract back into JSON

--- a/scripts/deployment/staking/deploy_03_gnosis_deposit_processor.sh
+++ b/scripts/deployment/staking/deploy_03_gnosis_deposit_processor.sh
@@ -8,14 +8,14 @@ reset=$(tput sgr0)
 globals="$(dirname "$0")/globals_$1.json"
 if [ ! -f $globals ]; then
   echo "${red}!!! $globals is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Get globals file for L2
 globalsL2="$(dirname "$0")/gnosis/globals_gnosis_$1.json"
 if [ ! -f $globalsL2 ]; then
   echo "${red}!!! $globalsL2 is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Read variables using jq
@@ -41,7 +41,7 @@ if [[ "$networkURL" == *"alchemy.com"* ]]; then
   esac
   if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
     echo "set $keyName env variable"
-    exit 0
+    exit 1
   fi
 fi
 
@@ -75,7 +75,7 @@ outputLength=${#gnosisDepositProcessorL1Address}
 # Check for the deployed address
 if [ $outputLength != 42 ]; then
   echo "${red}!!! The contract was not deployed...${reset}"
-  exit 0
+  exit 1
 fi
 
 # Write new deployed contract back into JSON

--- a/scripts/deployment/staking/deploy_04_optimism_deposit_processor.sh
+++ b/scripts/deployment/staking/deploy_04_optimism_deposit_processor.sh
@@ -8,14 +8,14 @@ reset=$(tput sgr0)
 globals="$(dirname "$0")/globals_$1.json"
 if [ ! -f $globals ]; then
   echo "${red}!!! $globals is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Get globals file for L2
 globalsL2="$(dirname "$0")/optimism/globals_optimism_$1.json"
 if [ ! -f $globalsL2 ]; then
   echo "${red}!!! $globalsL2 is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Read variables using jq
@@ -42,7 +42,7 @@ if [[ "$networkURL" == *"alchemy.com"* ]]; then
   esac
   if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
     echo "set $keyName env variable"
-    exit 0
+    exit 1
   fi
 fi
 
@@ -76,7 +76,7 @@ outputLength=${#optimismDepositProcessorL1Address}
 # Check for the deployed address
 if [ $outputLength != 42 ]; then
   echo "${red}!!! The contract was not deployed...${reset}"
-  exit 0
+  exit 1
 fi
 
 # Write new deployed contract back into JSON

--- a/scripts/deployment/staking/deploy_05_celo_deposit_processor.sh
+++ b/scripts/deployment/staking/deploy_05_celo_deposit_processor.sh
@@ -8,14 +8,14 @@ reset=$(tput sgr0)
 globals="$(dirname "$0")/globals_$1.json"
 if [ ! -f $globals ]; then
   echo "${red}!!! $globals is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Get globals file for L2
 globalsL2="$(dirname "$0")/celo/globals_celo_$1.json"
 if [ ! -f $globalsL2 ]; then
   echo "${red}!!! $globalsL2 is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Read variables using jq
@@ -42,7 +42,7 @@ if [[ "$networkURL" == *"alchemy.com"* ]]; then
   esac
   if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
     echo "set $keyName env variable"
-    exit 0
+    exit 1
   fi
 fi
 
@@ -76,7 +76,7 @@ outputLength=${#celoDepositProcessorL1Address}
 # Check for the deployed address
 if [ $outputLength != 42 ]; then
   echo "${red}!!! The contract was not deployed...${reset}"
-  exit 0
+  exit 1
 fi
 
 # Write new deployed contract back into JSON

--- a/scripts/deployment/staking/deploy_06_polygon_deposit_processor.sh
+++ b/scripts/deployment/staking/deploy_06_polygon_deposit_processor.sh
@@ -8,14 +8,14 @@ reset=$(tput sgr0)
 globals="$(dirname "$0")/globals_$1.json"
 if [ ! -f $globals ]; then
   echo "${red}!!! $globals is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Get globals file for L2
 globalsL2="$(dirname "$0")/polygon/globals_polygon_$1.json"
 if [ ! -f $globalsL2 ]; then
   echo "${red}!!! $globalsL2 is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Read variables using jq
@@ -43,7 +43,7 @@ if [[ "$networkURL" == *"alchemy.com"* ]]; then
   esac
   if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
     echo "set $keyName env variable"
-    exit 0
+    exit 1
   fi
 fi
 
@@ -77,7 +77,7 @@ outputLength=${#polygonDepositProcessorL1Address}
 # Check for the deployed address
 if [ $outputLength != 42 ]; then
   echo "${red}!!! The contract was not deployed...${reset}"
-  exit 0
+  exit 1
 fi
 
 # Write new deployed contract back into JSON

--- a/scripts/deployment/staking/deploy_07_base_deposit_processor.sh
+++ b/scripts/deployment/staking/deploy_07_base_deposit_processor.sh
@@ -8,14 +8,14 @@ reset=$(tput sgr0)
 globals="$(dirname "$0")/globals_$1.json"
 if [ ! -f $globals ]; then
   echo "${red}!!! $globals is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Get globals file for L2
 globalsL2="$(dirname "$0")/base/globals_base_$1.json"
 if [ ! -f $globalsL2 ]; then
   echo "${red}!!! $globalsL2 is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Read variables using jq
@@ -42,7 +42,7 @@ if [[ "$networkURL" == *"alchemy.com"* ]]; then
   esac
   if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
     echo "set $keyName env variable"
-    exit 0
+    exit 1
   fi
 fi
 
@@ -76,7 +76,7 @@ outputLength=${#baseDepositProcessorL1Address}
 # Check for the deployed address
 if [ $outputLength != 42 ]; then
   echo "${red}!!! The contract was not deployed...${reset}"
-  exit 0
+  exit 1
 fi
 
 # Write new deployed contract back into JSON

--- a/scripts/deployment/staking/deploy_08_eth_deposit_processor.sh
+++ b/scripts/deployment/staking/deploy_08_eth_deposit_processor.sh
@@ -8,7 +8,7 @@ reset=$(tput sgr0)
 globals="$(dirname "$0")/globals_$1.json"
 if [ ! -f $globals ]; then
   echo "${red}!!! $globals is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Read variables using jq
@@ -33,7 +33,7 @@ if [[ "$networkURL" == *"alchemy.com"* ]]; then
   esac
   if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
     echo "set $keyName env variable"
-    exit 0
+    exit 1
   fi
 fi
 
@@ -67,7 +67,7 @@ outputLength=${#ethereumDepositProcessorAddress}
 # Check for the deployed address
 if [ $outputLength != 42 ]; then
   echo "${red}!!! The contract was not deployed...${reset}"
-  exit 0
+  exit 1
 fi
 
 # Write new deployed contract back into JSON

--- a/scripts/deployment/staking/deploy_11_mode_deposit_processor.sh
+++ b/scripts/deployment/staking/deploy_11_mode_deposit_processor.sh
@@ -8,14 +8,14 @@ reset=$(tput sgr0)
 globals="$(dirname "$0")/globals_$1.json"
 if [ ! -f $globals ]; then
   echo "${red}!!! $globals is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Get globals file for L2
 globalsL2="$(dirname "$0")/mode/globals_mode_$1.json"
 if [ ! -f $globalsL2 ]; then
   echo "${red}!!! $globalsL2 is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Read variables using jq
@@ -42,7 +42,7 @@ if [[ "$networkURL" == *"alchemy.com"* ]]; then
   esac
   if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
     echo "set $keyName env variable"
-    exit 0
+    exit 1
   fi
 fi
 
@@ -76,7 +76,7 @@ outputLength=${#modeDepositProcessorL1Address}
 # Check for the deployed address
 if [ $outputLength != 42 ]; then
   echo "${red}!!! The contract was not deployed...${reset}"
-  exit 0
+  exit 1
 fi
 
 # Write new deployed contract back into JSON

--- a/scripts/deployment/staking/deploy_13_robinhood_deposit_processor.sh
+++ b/scripts/deployment/staking/deploy_13_robinhood_deposit_processor.sh
@@ -51,7 +51,7 @@ if [[ "$networkURL" == *"alchemy.com"* ]]; then
   esac
   if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
     echo "set $keyName env variable"
-    exit 0
+    exit 1
   fi
 fi
 

--- a/scripts/deployment/staking/gnosis/deploy_03_gnosis_target_dispenser.sh
+++ b/scripts/deployment/staking/gnosis/deploy_03_gnosis_target_dispenser.sh
@@ -8,14 +8,14 @@ reset=$(tput sgr0)
 globals="$(dirname "$0")/globals_$1.json"
 if [ ! -f $globals ]; then
   echo "${red}!!! $globals is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Get globals file for L1: globals_mainnet or globals_sepolia
 globalsL1="$(dirname "$0")/../globals_${1#*_}.json"
 if [ ! -f $globalsL1 ]; then
   echo "${red}!!! $globalsL1 is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Read variables using jq
@@ -41,7 +41,7 @@ if [[ "$networkURL" == *"alchemy.com"* ]]; then
   esac
   if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
     echo "set $keyName env variable"
-    exit 0
+    exit 1
   fi
 fi
 
@@ -75,7 +75,7 @@ outputLength=${#gnosisTargetDispenserL2Address}
 # Check for the deployed address
 if [ $outputLength != 42 ]; then
   echo "${red}!!! The contract was not deployed...${reset}"
-  exit 0
+  exit 1
 fi
 
 # Write new deployed contract back into JSON

--- a/scripts/deployment/staking/mode/deploy_11_mode_target_dispenser.sh
+++ b/scripts/deployment/staking/mode/deploy_11_mode_target_dispenser.sh
@@ -8,14 +8,14 @@ reset=$(tput sgr0)
 globals="$(dirname "$0")/globals_$1.json"
 if [ ! -f $globals ]; then
   echo "${red}!!! $globals is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Get globals file for L1: globals_mainnet or globals_sepolia
 globalsL1="$(dirname "$0")/../globals_${1#*_}.json"
 if [ ! -f $globalsL1 ]; then
   echo "${red}!!! $globalsL1 is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Read variables using jq
@@ -41,7 +41,7 @@ if [[ "$networkURL" == *"alchemy.com"* ]]; then
   esac
   if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
     echo "set $keyName env variable"
-    exit 0
+    exit 1
   fi
 fi
 
@@ -75,7 +75,7 @@ outputLength=${#modeTargetDispenserL2Address}
 # Check for the deployed address
 if [ $outputLength != 42 ]; then
   echo "${red}!!! The contract was not deployed...${reset}"
-  exit 0
+  exit 1
 fi
 
 # Write new deployed contract back into JSON

--- a/scripts/deployment/staking/multi_deploy_01_processor_dispenser_link.sh
+++ b/scripts/deployment/staking/multi_deploy_01_processor_dispenser_link.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+# Chains the three cross-chain staking deployment steps for one network:
+#   L1 deposit processor -> L2 target dispenser -> link the two.
+#
+# set -e is load-bearing here. Each step binds the NEXT one by address, and two of those bindings are
+# `immutable`: DefaultDepositProcessorL1.l1Dispenser, and the aliased l1DepositProcessor that
+# DefaultTargetDispenserL2 computes in its constructor. Without set -e a failed step would print its error,
+# return non-zero, and the chain would continue with a stale or empty address from the globals — deploying a
+# dispenser bound to the wrong processor, which cannot be corrected afterwards.
+set -e
+
 # Get network name from network_mainnet or network_sepolia or another testnet
 network=${1%_*}
 
@@ -7,7 +17,7 @@ network=${1%_*}
 # Get mainnet or testnet string from network_mainnet or network_sepolia or another testnet
 ./scripts/deployment/staking/deploy_*_${network}_deposit_processor.sh ${1#*_}
 
-# No further L2 deployment is needed for ethereum
+# No further L2 deployment is needed for ethereum. This is a legitimate early success, not a failure.
 if [ "$network" == "eth" ]; then
   exit 0
 fi

--- a/scripts/deployment/staking/optimism/deploy_04_optimism_target_dispenser.sh
+++ b/scripts/deployment/staking/optimism/deploy_04_optimism_target_dispenser.sh
@@ -8,14 +8,14 @@ reset=$(tput sgr0)
 globals="$(dirname "$0")/globals_$1.json"
 if [ ! -f $globals ]; then
   echo "${red}!!! $globals is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Get globals file for L1: globals_mainnet or globals_sepolia
 globalsL1="$(dirname "$0")/../globals_${1#*_}.json"
 if [ ! -f $globalsL1 ]; then
   echo "${red}!!! $globalsL1 is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Read variables using jq
@@ -41,7 +41,7 @@ if [[ "$networkURL" == *"alchemy.com"* ]]; then
   esac
   if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
     echo "set $keyName env variable"
-    exit 0
+    exit 1
   fi
 fi
 
@@ -75,7 +75,7 @@ outputLength=${#optimismTargetDispenserL2Address}
 # Check for the deployed address
 if [ $outputLength != 42 ]; then
   echo "${red}!!! The contract was not deployed...${reset}"
-  exit 0
+  exit 1
 fi
 
 # Write new deployed contract back into JSON

--- a/scripts/deployment/staking/polygon/deploy_06_polygon_target_dispenser.sh
+++ b/scripts/deployment/staking/polygon/deploy_06_polygon_target_dispenser.sh
@@ -8,14 +8,14 @@ reset=$(tput sgr0)
 globals="$(dirname "$0")/globals_$1.json"
 if [ ! -f $globals ]; then
   echo "${red}!!! $globals is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Get globals file for L1: globals_mainnet or globals_sepolia
 globalsL1="$(dirname "$0")/../globals_${1#*_}.json"
 if [ ! -f $globalsL1 ]; then
   echo "${red}!!! $globalsL1 is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Read variables using jq
@@ -41,7 +41,7 @@ if [[ "$networkURL" == *"alchemy.com"* ]]; then
   esac
   if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
     echo "set $keyName env variable"
-    exit 0
+    exit 1
   fi
 fi
 
@@ -75,7 +75,7 @@ outputLength=${#polygonTargetDispenserL2Address}
 # Check for the deployed address
 if [ $outputLength != 42 ]; then
   echo "${red}!!! The contract was not deployed...${reset}"
-  exit 0
+  exit 1
 fi
 
 # Write new deployed contract back into JSON

--- a/scripts/deployment/staking/robinhood/deploy_02_robinhood_target_dispenser.sh
+++ b/scripts/deployment/staking/robinhood/deploy_02_robinhood_target_dispenser.sh
@@ -59,7 +59,7 @@ if [[ "$networkURL" == *"alchemy.com"* ]]; then
   esac
   if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
     echo "set $keyName env variable"
-    exit 0
+    exit 1
   fi
 fi
 

--- a/scripts/deployment/staking/script_01_set_target_dispenser_l2.sh
+++ b/scripts/deployment/staking/script_01_set_target_dispenser_l2.sh
@@ -11,14 +11,14 @@ network=${1%_*}
 globals="$(dirname "$0")/globals_${1#*_}.json"
 if [ ! -f $globals ]; then
   echo "${red}!!! $globals is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Get globals file for L2
 globalsL2="$(dirname "$0")/${network}/globals_$1.json"
 if [ ! -f $globalsL2 ]; then
   echo "${red}!!! $globalsL2 is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Read variables using jq
@@ -41,7 +41,7 @@ if [[ "$networkURL" == *"alchemy.com"* ]]; then
   esac
   if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
     echo "set $keyName env variable"
-    exit 0
+    exit 1
   fi
 fi
 

--- a/scripts/deployment/staking/script_02_set_target_dispenser_l2_all.sh
+++ b/scripts/deployment/staking/script_02_set_target_dispenser_l2_all.sh
@@ -8,7 +8,7 @@ reset=$(tput sgr0)
 globals="$(dirname "$0")/globals_$1.json"
 if [ ! -f $globals ]; then
   echo "${red}!!! $globals is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Read variables using jq
@@ -42,7 +42,7 @@ if [[ "$networkURL" == *"alchemy.com"* ]]; then
   esac
   if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
     echo "set $keyName env variable"
-    exit 0
+    exit 1
   fi
 fi
 

--- a/scripts/deployment/staking/script_03_set_deposit_processor_l1_polygon.sh
+++ b/scripts/deployment/staking/script_03_set_deposit_processor_l1_polygon.sh
@@ -11,14 +11,14 @@ network=${1%_*}
 globals="$(dirname "$0")/globals_${1#*_}.json"
 if [ ! -f $globals ]; then
   echo "${red}!!! $globals is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Get globals file for L2
 globalsL2="$(dirname "$0")/${network}/globals_$1.json"
 if [ ! -f $globalsL2 ]; then
   echo "${red}!!! $globalsL2 is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Read variables using jq
@@ -41,7 +41,7 @@ if [[ "$networkURL" == *"alchemy.com"* ]]; then
   esac
   if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
     echo "set $keyName env variable"
-    exit 0
+    exit 1
   fi
 fi
 

--- a/scripts/deployment/staking/script_04_target_dispenser_l2_change_owner.sh
+++ b/scripts/deployment/staking/script_04_target_dispenser_l2_change_owner.sh
@@ -11,7 +11,7 @@ network=${1%_*}
 globals="$(dirname "$0")/${network}/globals_$1.json"
 if [ ! -f $globals ]; then
   echo "${red}!!! $globals is not found${reset}"
-  exit 0
+  exit 1
 fi
 
 # Read variables using jq
@@ -33,7 +33,7 @@ if [[ "$networkURL" == *"alchemy.com"* ]]; then
   esac
   if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
     echo "set $keyName env variable"
-    exit 0
+    exit 1
   fi
 fi
 


### PR DESCRIPTION
Backport of the exit-code fix from #357/#358, which applied it to the two new Robinhood scripts only — leaving the tree with two conventions for the same failure mode, and the next chain script templated off whichever sibling someone opens first. Raised separately because it touches every chain's deploy path. Requested by @OjusWiZard in the #357 review.

## The exit codes — 21 scripts

Every `exit 0` that follows an error message becomes `exit 1`:

| branch | fires when |
|---|---|
| `$globals` / `$globalsL1` / `$globalsL2` not found | wrong network argument |
| `set $keyName env variable` | missing Alchemy key |
| `The contract was not deployed...` | **`forge create` returned no address** — rejected Ledger signature, RPC error, bad constructor args |

**One `exit 0` is deliberately kept:** `multi_deploy`'s early return for ethereum, which is a legitimate success — no L2 deployment is needed there.

## The exit codes alone would not have been enough

`multi_deploy_01_processor_dispenser_link.sh` chains its three steps as bare commands — **no `set -e`, no `&&`** — so a non-zero return was discarded and the chain continued anyway.

It now sets `set -e`, and that is load-bearing rather than hygiene. Each step binds the next **by address**, and two of those bindings are `immutable`: `DefaultDepositProcessorL1.l1Dispenser`, and the aliased `l1DepositProcessor` that `DefaultTargetDispenserL2` computes in its constructor. A dispenser deployed against a stale processor address **cannot be corrected afterwards** — it needs both contracts redeployed.

Demonstrated with a stubbed chain where step 1 fails:

```
before   [step 1] simulating forge failure
         !!! The contract was not deployed...
         [step 2] L2 dispenser RAN — would bind to a stale l1DepositProcessor (immutable!)
         [step 3] link RAN
         chain exit=0

after    [step 1] simulating forge failure
         !!! The contract was not deployed...
         chain exit=1
```

No behavioural change on a successful run.

## Why now

This is on the critical path for the Robinhood Chain rollout: §3.4 of the plan (valory-xyz/autonolas-analytics#254) runs exactly this chain, and it is the step where a silent continuation would produce an unrecoverable binding.
