### PR TITLE
audit: name the check that actually runs in the failure summary

### DIFF
--- a/scripts/audit_chains/audit_contracts_setup.js
+++ b/scripts/audit_chains/audit_contracts_setup.js
@@ -1695,7 +1695,7 @@ async function main() {
 main()
     .then(() => {
         if (bytecodeMismatchFound) {
-            console.error("AUDIT FAILED: at least one contract does not match its artifact (Tier 1: length, or Tier 1b: a differing run too long to be an immutable) — see FAIL lines above.");
+            console.error("AUDIT FAILED: at least one contract does not match its artifact (Tier 1: code length, or Tier 1b: bytes differing outside the artifact's unfilled PUSH32 immutable slots) — see FAIL lines above.");
             process.exit(1);
         }
         process.exit(0);


### PR DESCRIPTION
#363 replaced Tier 1b's run-length threshold with the unfilled-`PUSH32`-slot comparison but left `main()`'s `console.error` describing the old one:

```
AUDIT FAILED: ... Tier 1b: a differing run too long to be an immutable
```

A FAIL therefore pointed operators at a threshold that no longer exists. Now:

```
AUDIT FAILED: ... Tier 1b: bytes differing outside the artifact's unfilled PUSH32 immutable slots
```

Caught by @dagacha on the merged PR. It is the same fix #362 made to this line — I made it once and then did not repeat it when the check changed underneath.