### PR TITLE
fix(utils): BuyBackBurner change-owner script could not run on macOS

### DIFF
--- a/scripts/deployment/utils/script_02_buy_back_burner_change_owner.sh
+++ b/scripts/deployment/utils/script_02_buy_back_burner_change_owner.sh
@@ -84,16 +84,33 @@ fi
 
 # Pre-flight: current owner must equal the signer; otherwise changeOwner reverts.
 currentOwner=$(cast call --rpc-url $networkURL$API_KEY $buyBackBurnerProxyAddress "owner()(address)")
-if [ "${currentOwner,,}" != "${deployer,,}" ]; then
-  echo "${red}!!! Signer $deployer is not the current BBB proxy owner ($currentOwner).${reset}"
-  echo "${red}    Set derivationPath in $globals to the path that controls $currentOwner, then re-run.${reset}"
+# A failed call returns an empty string, which would otherwise compare unequal to the signer and
+# report a missing derivation path for an owner that was never read.
+if ! [[ "$currentOwner" =~ ^0x[0-9a-fA-F]{40}$ ]]; then
+  echo "${red}!!! Failed to read BuyBackBurner proxy owner() (got: $currentOwner)${reset}"
   exit 1
 fi
 
-# No-op if already owned by the target
-if [ "${currentOwner,,}" == "${newOwnerAddress,,}" ]; then
+# Addresses are lowercased with tr rather than the ${var,,} expansion, which is bash 4 only: macOS
+# still ships bash 3.2, where it aborts the script with "bad substitution". That failed safe here,
+# before the cast send below, but it meant this handover could not be completed from a Mac at all.
+currentOwnerLc=$(echo "$currentOwner" | tr '[:upper:]' '[:lower:]')
+deployerLc=$(echo "$deployer" | tr '[:upper:]' '[:lower:]')
+newOwnerLc=$(echo "$newOwnerAddress" | tr '[:upper:]' '[:lower:]')
+
+# The already-done case is tested before the signer check, not after it. Once the handover has
+# succeeded the signer is by definition no longer the owner, so the original order reported a
+# completed transfer as a hard failure telling the operator to find a derivation path for the
+# bridge mediator - an address nobody holds a key for.
+if [ "$currentOwnerLc" == "$newOwnerLc" ]; then
   echo "${green}BuyBackBurner proxy $buyBackBurnerProxyAddress is already owned by $newOwnerAddress. Nothing to do.${reset}"
   exit 0
+fi
+
+if [ "$currentOwnerLc" != "$deployerLc" ]; then
+  echo "${red}!!! Signer $deployer is not the current BBB proxy owner ($currentOwner).${reset}"
+  echo "${red}    Set derivationPath in $globals to the path that controls $currentOwner, then re-run.${reset}"
+  exit 1
 fi
 
 castSendHeader="cast send --rpc-url $networkURL$API_KEY $walletArgs"


### PR DESCRIPTION
`scripts/deployment/utils/script_02_buy_back_burner_change_owner.sh` cannot run on macOS.

`${currentOwner,,}` (lines 87 and 94) is a bash 4 expansion. macOS still ships bash 3.2, where it aborts with `bad substitution`:

```
$ /bin/bash --version
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)
$ /bin/bash -c 'x=0xABC; echo "${x,,}"'
/bin/bash: ${x,,}: bad substitution
```

The abort lands at the pre-flight, before the `cast send`, so it fails safe — but it means this ownership handover cannot be completed from a Mac at all. It is the only one of the ten `changeOwner` scripts in the three repos affected; the registries `l2` scripts already lowercase with `tr` and carry a comment saying why.

Two further defects in the same block, both of which would have surfaced during a real handover:

**The already-done check ran after the signer check.** Once the transfer has succeeded the signer is by definition no longer the owner, so re-running reported a completed handover as a hard failure — advising the operator to set a derivation path for the bridge mediator, an address nobody holds a key for. The target test now runs first, which is what makes the script idempotent.

**`owner()` was used without a shape check.** A failed call returns an empty string, which compares unequal to the signer and produces that same misleading message for an owner that was never read.

All five branches — pre-handover, already handed over, checksum vs lowercase mismatch, wrong signer, unreadable owner — exercised under `/bin/bash` 3.2.57.

Found while auditing the ownership handover for chain 4663, where this script transfers `BuyBackBurnerProxy`. It applies to every chain that uses it.
